### PR TITLE
Elasticsearch logging

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -27,3 +27,9 @@ OBJECT_STORE_ENABLED = False
 MINIO_URL = 'localhost:9000'
 MINIO_ACCESS_KEY = 'miniouser'
 MINIO_SECRET_KEY = 'leftfoot1'
+
+ELASTIC_SEARCH_LOGGING_ENABLED = False
+ES_HOST = 'host'
+ES_PORT = '9200'
+ES_USER = 'user'
+ES_PASS = 'pass'

--- a/servicex/elasticsearch_adaptor.py
+++ b/servicex/elasticsearch_adaptor.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-class Elasticsearch_monitoring:
+class ElasticSearchAdapter:
 
     def __init__(self, url, port, username, password):
         from elasticsearch import Elasticsearch

--- a/servicex/elasticsearch_monitoring.py
+++ b/servicex/elasticsearch_monitoring.py
@@ -25,46 +25,29 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import io
 
-from setuptools import find_packages, setup
 
-with io.open('README.rst', 'rt', encoding='utf8') as f:
-    readme = f.read()
+class Elasticsearch_monitoring:
 
-setup(
-    name='servicex',
-    version='1.0.0',
-    url='https://iris-hep.org',
-    license='BSD',
-    maintainer='ServiceX Team',
-    maintainer_email='bengal1@illinois.edu',
-    description='REST Frontend to ServiceX.',
-    long_description=readme,
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=[
-        'flask',
-        'Flask-WTF',
-        'pika',
-        'flask-restful',
-        'flask-jwt-extended',
-        'passlib',
-        'flask-sqlalchemy',
-        'Flask-Migrate',
-        'confluent_kafka',
-        'kubernetes',
-        'minio',
-        'elasticsearch'
-    ],
-    extras_require={
-        'test': [
-            'pytest>=3.6',
-            'pytest-flask',
-            'coverage',
-            'pytest-mock',
-            'flake8'
-        ],
-    },
-)
+    def __init__(self, url, port, username, password):
+        from elasticsearch import Elasticsearch
+        self.es_monitor = Elasticsearch(
+            hosts=[url + ":" + port],
+            http_auth=(username, password)
+        )
+
+    def create_update_request(self, req_id, state):
+        res = self.es_monitor.index(
+            index="servicex",
+            id=req_id,
+            body=state
+        )
+        print('request update:', res['result'])
+
+    def create_update_path(self, path_id, state):
+        res = self.es_monitor.index(
+            index="servicex_paths",
+            id=path_id,
+            body=state
+        )
+        print('path update:', res['result'])

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -26,7 +26,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from sqlalchemy import func, ForeignKey
-from passlib.hash import pbkdf2_sha256 as sha256
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
@@ -50,7 +49,8 @@ class TransformRequest(db.Model):
         }
 
     id = db.Column(db.Integer, primary_key=True)
-    did = db.Column(db.String(120), unique=False, nullable=False)
+    submit_time = db.Column(db.DateTime, nullable=False)
+    did = db.Column(db.String(512), unique=False, nullable=False)
     columns = db.Column(db.String(1024), unique=False, nullable=False)
     request_id = db.Column(db.String(48), unique=True, nullable=False)
     image = db.Column(db.String(128), nullable=True)
@@ -62,8 +62,8 @@ class TransformRequest(db.Model):
 
     files = db.Column(db.Integer, nullable=True)
     files_skipped = db.Column(db.Integer, nullable=True)
-    total_events = db.Column(db.Integer, nullable=True)
-    total_bytes = db.Column(db.Integer, nullable=True)
+    total_events = db.Column(db.BigInteger, nullable=True)
+    total_bytes = db.Column(db.BigInteger, nullable=True)
     did_lookup_time = db.Column(db.Integer, nullable=True)
 
     def save_to_db(self):
@@ -97,14 +97,14 @@ class TransformationResult(db.Model):
     __tablename__ = 'transform_result'
 
     id = db.Column(db.Integer, primary_key=True)
-    did = db.Column(db.String(120), unique=False, nullable=False)
+    did = db.Column(db.String(512), unique=False, nullable=False)
     file_id = db.Column(db.Integer, ForeignKey('files.id'))
-    file_path = db.Column(db.String(120), unique=False, nullable=False)
+    file_path = db.Column(db.String(512), unique=False, nullable=False)
     request_id = db.Column(db.String(48), unique=False, nullable=False)
-    transform_status = db.Column(db.String(10), nullable=False)
+    transform_status = db.Column(db.String(120), nullable=False)
     transform_time = db.Column(db.Integer, nullable=True)
-    total_events = db.Column(db.Integer, nullable=True)
-    total_bytes = db.Column(db.Integer, nullable=True)
+    total_events = db.Column(db.BigInteger, nullable=True)
+    total_bytes = db.Column(db.BigInteger, nullable=True)
     avg_rate = db.Column(db.Float, nullable=True)
     messages = db.Column(db.Integer, nullable=True)
 
@@ -146,8 +146,9 @@ class TransformationResult(db.Model):
         return cls.query.filter(TransformationResult.request_id == request_id).all()
 
     @classmethod
-    def statistics(cls, request_id):
-        rslt = cls.query.add_columns(
+    def statistics(cls, request_key):
+        rslt_list = db.session.query(
+            TransformationResult.request_id,
             func.sum(TransformationResult.messages).label('total_msgs'),
             func.min(TransformationResult.transform_time).label('min_time'),
             func.max(TransformationResult.transform_time).label('max_time'),
@@ -156,18 +157,23 @@ class TransformationResult(db.Model):
             func.avg(TransformationResult.avg_rate).label('avg_rate'),
             func.sum(TransformationResult.total_bytes).label('total_bytes'),
             func.sum(TransformationResult.total_events).label('total_events')
+        ).group_by(TransformationResult.request_id).filter_by(
+            request_id=request_key).all()
 
-        ).filter_by(request_id=request_id).one()
+        if len(rslt_list) == 0:
+            return None
+
+        rslt = rslt_list[0]
 
         return {
-            "total-messages": rslt.total_msgs,
-            "min-time": rslt.min_time,
-            "max-time": rslt.max_time,
-            "avg-time": rslt.avg_time,
-            "total-time": rslt.total_time,
-            "avg-rate": rslt.avg_rate,
-            "total-bytes": rslt.total_bytes,
-            "total-events": rslt.total_events
+            "total-messages": int(rslt.total_msgs),
+            "min-time": int(rslt.min_time),
+            "max-time": int(rslt.max_time),
+            "avg-time": float(rslt.avg_time),
+            "total-time": int(rslt.total_time),
+            "avg-rate": float(rslt.avg_rate),
+            "total-bytes": int(rslt.total_bytes),
+            "total-events": int(rslt.total_events)
         }
 
 
@@ -175,13 +181,15 @@ class DatasetFile(db.Model):
     __tablename__ = 'files'
 
     id = db.Column(db.Integer, primary_key=True)
-    request_id = db.Column(db.String(48), ForeignKey('requests.request_id'),
-                           unique=False, nullable=False)
-    file_path = db.Column(db.String(120), unique=False, nullable=False)
+    request_id = db.Column(db.String(48),
+                           ForeignKey('requests.request_id'),
+                           unique=False,
+                           nullable=False)
+    file_path = db.Column(db.String(512), unique=False, nullable=False)
 
     adler32 = db.Column(db.String(48), nullable=True)
-    file_size = db.Column(db.Integer, nullable=True)
-    file_events = db.Column(db.Integer, nullable=True)
+    file_size = db.Column(db.BigInteger, nullable=True)
+    file_events = db.Column(db.BigInteger, nullable=True)
 
     def save_to_db(self):
         db.session.add(self)
@@ -193,46 +201,3 @@ class DatasetFile(db.Model):
 
     def get_path_id(self):
         return self.request_id+":"+str(self.id)
-
-
-class UserModel(db.Model):
-    __tablename__ = 'users'
-
-    id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(120), unique=True, nullable=False)
-    password = db.Column(db.String(120), nullable=False)
-
-    def save_to_db(self):
-        db.session.add(self)
-        db.session.commit()
-
-    @staticmethod
-    def generate_hash(password):
-        return sha256.hash(password)
-
-    @staticmethod
-    def verify_hash(password, hash):
-        return sha256.verify(password, hash)
-
-    @classmethod
-    def find_by_username(cls, username):
-        return cls.query.filter_by(username=username).first()
-
-    @classmethod
-    def return_all(cls):
-        def to_json(x):
-            return {
-                'username': x.username,
-                'password': x.password
-            }
-
-        return {'users': list(map(lambda x: to_json(x), UserModel.query.all()))}
-
-    @classmethod
-    def delete_all(cls):
-        try:
-            num_rows_deleted = db.session.query(cls).delete()
-            db.session.commit()
-            return {'message': '{} row(s) deleted'.format(num_rows_deleted)}
-        except Exception:
-            return {'message': 'Something went wrong'}

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -30,6 +30,8 @@ from flask import current_app
 from datetime import datetime
 from datetime import timezone
 
+from servicex.models import TransformationResult
+
 
 class ServiceXResource(Resource):
     @staticmethod
@@ -52,4 +54,29 @@ class ServiceXResource(Resource):
             "last_accessed_at": time,
             "events_served": 0,
             "retries": 0
+        }
+
+    def _generate_transformation_record(self, submitted_request, status):
+        request_id = submitted_request.request_id
+        count = TransformationResult.count(request_id)
+        time = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        current_stats = TransformationResult.statistics(request_id)
+
+        events_transformed = 0 if not current_stats else current_stats['total-events']
+        return {
+            "name": 'Transformation Request',
+            "description": 'Transformation Request',
+            "dataset": submitted_request.did,
+            "dataset_size": int(submitted_request.total_bytes or 0),
+            "dataset_files": count,
+            "dataset_events": int(submitted_request.total_events or 0),
+            "columns": submitted_request.columns,
+            "events": 0,
+            "events_transformed": events_transformed,
+            "events_served": 0,
+            "events_processed": 0,
+            "created_at": submitted_request.submit_time,
+            "modified_at": time,
+            "status": status,
+            "info": ' '
         }

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -27,10 +27,29 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from flask_restful import Resource
 from flask import current_app
+from datetime import datetime
+from datetime import timezone
 
 
 class ServiceXResource(Resource):
-
     @staticmethod
     def _generate_advertised_endpoint(endpoint):
         return "http://" + current_app.config['ADVERTISED_HOSTNAME'] + "/" + endpoint
+
+    @staticmethod
+    def _generate_file_status_record(dataset_file, status):
+        time = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+        return {
+            "req_id": dataset_file.request_id,
+            "adler32": dataset_file.adler32,
+            "file_size": dataset_file.file_size,
+            "file_events": dataset_file.file_events,
+            "file_path": dataset_file.file_path,
+            "status": status,
+            "info": 'info',
+            "created_at": time,
+            "last_accessed_at": time,
+            "events_served": 0,
+            "retries": 0
+        }

--- a/servicex/resources/transform_status.py
+++ b/servicex/resources/transform_status.py
@@ -50,7 +50,6 @@ class TransformationStatus(ServiceXResource):
         print(status)
 
     def get(self, request_id):
-        print("\n\n-------->.", request_id)
         status_request = status_request_parser.parse_args()
 
         count = TransformationResult.count(request_id)

--- a/servicex/resources/transformer_file_complete.py
+++ b/servicex/resources/transformer_file_complete.py
@@ -27,33 +27,79 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from flask import request, current_app
 
-from servicex.models import TransformRequest, TransformationResult
+from servicex.models import TransformRequest, TransformationResult, DatasetFile
 from servicex.resources.servicex_resource import ServiceXResource
+from datetime import datetime
+from datetime import timezone
 
 
 class TransformerFileComplete(ServiceXResource):
     @classmethod
-    def make_api(cls, transformer_manager):
+    def make_api(cls, transformer_manager, elasticsearch_adapter):
         cls.transformer_manager = transformer_manager
+        cls.elasticsearch_adapter = elasticsearch_adapter
         return cls
+
+    def _generate_transformation_record(self, transformation_result, submitted_request):
+        request_id = submitted_request.request_id
+        count = TransformationResult.count(request_id)
+        time = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+        return {
+            "name": 'Transformation Request',
+            "description": 'Transformation Request',
+            "dataset": submitted_request.did,
+            "dataset_size": 0,
+            "dataset_files": count,
+            "dataset_events": 0,
+            "columns": submitted_request.columns,
+            "events": 0,
+            "events_transformed": 0,
+            "events_served": 0,
+            "events_processed": 0,
+            "created_at": time,
+            "modified_at": time,
+            "status": 'complete',
+            "info": ' '
+        }
 
     def put(self, request_id):
         info = request.get_json()
         submitted_request = TransformRequest.return_request(request_id)
+        dataset_file = DatasetFile.get_by_id(info['file-id'])
+
         rec = TransformationResult(
             did=submitted_request.did,
+            file_id=dataset_file.id,
             request_id=request_id,
             file_path=info['file-path'],
             transform_status=info['status'],
             transform_time=info['total-time'],
+            total_bytes=info['total-bytes'],
+            total_events=info['total-events'],
+            avg_rate=info['avg-rate'],
             messages=info['num-messages']
         )
         rec.save_to_db()
+
+        if self.elasticsearch_adapter:
+            import uuid
+            path_id = str(uuid.uuid4())
+
+            self.elasticsearch_adapter.create_update_path(
+                path_id,
+                self._generate_file_status_record(dataset_file, info['status']))
 
         files_remaining = TransformRequest.files_remaining(request_id)
         if files_remaining is not None and files_remaining <= 0:
             namespace = current_app.config['TRANSFORMER_NAMESPACE']
             print("Job is all done... shutting down transformers")
             self.transformer_manager.shutdown_transformer_job(request_id, namespace)
+
+            if self.elasticsearch_adapter:
+                self.elasticsearch_adapter.create_update_request(
+                    request_id,
+                    self._generate_transformation_record(rec, submitted_request))
+
         print(info)
         return "Ok"

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -27,7 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-def add_routes(api, transformer_manager, rabbit_mq_adaptor, object_store):
+def add_routes(api, transformer_manager, rabbit_mq_adaptor,
+               object_store, elasticsearch_adapter):
     from servicex.resources.submit_transformation_request import SubmitTransformationRequest
     from servicex.resources.transform_start import TransformStart
     from servicex.resources.transform_status import TransformationStatus
@@ -47,7 +48,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor, object_store):
 
     api.add_resource(TransformationStatus, '/servicex/transformation/<string:request_id>/status')
 
-    AddFileToDataset.make_api(rabbit_mq_adaptor)
+    AddFileToDataset.make_api(rabbit_mq_adaptor, elasticsearch_adapter)
     api.add_resource(AddFileToDataset, '/servicex/transformation/<string:request_id>/files')
 
     PreflightCheck.make_api(rabbit_mq_adaptor)
@@ -58,6 +59,6 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor, object_store):
     TransformStart.make_api(transformer_manager)
     api.add_resource(TransformStart, '/servicex/transformation/<string:request_id>/start')
 
-    TransformerFileComplete.make_api(transformer_manager)
+    TransformerFileComplete.make_api(transformer_manager, elasticsearch_adapter)
     api.add_resource(TransformerFileComplete,
                      '/servicex/transformation/<string:request_id>/file-complete')

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -39,7 +39,8 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.resources.transformer_file_complete import TransformerFileComplete
 
     SubmitTransformationRequest.make_api(rabbitmq_adaptor=rabbit_mq_adaptor,
-                                         object_store=object_store)
+                                         object_store=object_store,
+                                         elasticsearch_adapter=elasticsearch_adapter)
     api.add_resource(SubmitTransformationRequest, '/servicex/transformation')
 
     api.add_resource(QueryTransformationRequest,

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'confluent_kafka',
         'kubernetes',
         'minio',
-        'elasticsearch'
+        'elasticsearch',
+        'psycopg2'
     ],
     extras_require={
         'test': [

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -56,7 +56,8 @@ class ResourceTestBase:
     def _test_client(additional_config=None,
                      transformation_manager=None,
                      rabbit_adaptor=None,
-                     object_store=None):
+                     object_store=None,
+                     elasticsearch_adapter=None):
         config = ResourceTestBase._app_config()
         config['TRANSFORMER_MANAGER_ENABLED'] = False
         config['TRANSFORMER_MANAGER_MODE'] = 'external'
@@ -64,7 +65,8 @@ class ResourceTestBase:
         if additional_config:
             config.update(additional_config)
 
-        app = create_app(config, transformation_manager, rabbit_adaptor, object_store)
+        app = create_app(config, transformation_manager, rabbit_adaptor,
+                         object_store, elasticsearch_adapter)
 
         return app.test_client()
 

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -73,6 +73,7 @@ class ResourceTestBase:
     @staticmethod
     def _generate_transform_request():
         transform_request = TransformRequest()
+        transform_request.submit_time = 1000
         transform_request.request_id = 'BR549'
         transform_request.columns = 'electron.eta(), muon.pt()'
         transform_request.chunk_size = 1000
@@ -82,6 +83,8 @@ class ResourceTestBase:
         transform_request.result_destination = 'kafka'
         transform_request.result_format = 'arrow'
         transform_request.kafka_broker = 'http://ssl-hep.org.kafka:12345'
+        transform_request.total_events = 10000
+        transform_request.total_bytes = 1203
         return transform_request
 
     @fixture

--- a/tests/resources/test_add_file_to_dataset.py
+++ b/tests/resources/test_add_file_to_dataset.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import json
 
+from servicex import ElasticSearchAdapter
 from tests.resource_test_base import ResourceTestBase
 
 
@@ -37,10 +38,18 @@ class TestAddFileToDataset(ResourceTestBase):
             servicex.models.TransformRequest,
             'return_request',
             return_value=self._generate_transform_request())
+        mock_elasticsearch_adapter = mocker.MagicMock(ElasticSearchAdapter)
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   elasticsearch_adapter=mock_elasticsearch_adapter)
+
         response = client.put('/servicex/transformation/1234/files',
-                              json={'file_path': '/foo/bar.root'})
+                              json={
+                                  'file_path': '/foo/bar.root',
+                                  'adler32': '12345',
+                                  'file_size': 1024,
+                                  'file_events': 500
+                              })
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
         mock_rabbit_adaptor.basic_publish.assert_called_with(
@@ -48,6 +57,7 @@ class TestAddFileToDataset(ResourceTestBase):
             routing_key='1234',
             body=json.dumps(
                 {"request-id": 'BR549',
+                 "file-id": 1,
                  "columns": 'electron.eta(), muon.pt()',
                  "file-path": "/foo/bar.root",
                  "service-endpoint": "http://cern.analysis.ch:5000/servicex/transformation/1234",
@@ -55,9 +65,24 @@ class TestAddFileToDataset(ResourceTestBase):
                  'kafka-broker': 'http://ssl-hep.org.kafka:12345'
                  }))
 
+        call = mock_elasticsearch_adapter.create_update_path.mock_calls[0][1]
+        assert call[0] == '1234:1'
+
+        path_doc = call[1]
+        assert path_doc['req_id'] == '1234'
+
+        assert path_doc['adler32'] == '12345'
+        assert path_doc['file_size'] == 1024
+        assert path_doc['file_events'] == 500
+        assert path_doc['file_path'] == '/foo/bar.root'
+        assert path_doc['status'] == 'located'
+        assert path_doc['info'] == 'info'
+        assert path_doc['events_served'] == 0
+        assert path_doc['retries'] == 0
+
         assert response.json == {
             "request-id": '1234',
-            "file-id": 42
+            "file-id": 1
         }
 
     def test_put_new_file_root_dest(self, mocker,  mock_rabbit_adaptor):
@@ -72,9 +97,17 @@ class TestAddFileToDataset(ResourceTestBase):
             'return_request',
             return_value=root_file_transform_request)
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        mock_elasticsearch_adapter = mocker.MagicMock(ElasticSearchAdapter)
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   elasticsearch_adapter=mock_elasticsearch_adapter)
         response = client.put('/servicex/transformation/1234/files',
-                              json={'file_path': '/foo/bar.root'})
+                              json={
+                                  'file_path': '/foo/bar.root',
+                                  'adler32': '12345',
+                                  'file_size': 1024,
+                                  'file_events': 500
+                              })
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
         mock_rabbit_adaptor.basic_publish.assert_called_with(
@@ -82,6 +115,7 @@ class TestAddFileToDataset(ResourceTestBase):
             routing_key='1234',
             body=json.dumps(
                 {"request-id": 'BR549',
+                 "file-id": 1,
                  "columns": 'electron.eta(), muon.pt()',
                  "file-path": "/foo/bar.root",
                  "service-endpoint": "http://cern.analysis.ch:5000/servicex/transformation/1234",
@@ -90,7 +124,7 @@ class TestAddFileToDataset(ResourceTestBase):
 
         assert response.json == {
             "request-id": '1234',
-            "file-id": 42
+            "file-id": 1
         }
 
     def test_put_new_file_with_exception(self, mocker, mock_rabbit_adaptor):

--- a/tests/resources/test_transform_file_complete.py
+++ b/tests/resources/test_transform_file_complete.py
@@ -26,12 +26,25 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from servicex import TransformerManager
-from servicex.models import TransformRequest
+from servicex.models import TransformRequest, DatasetFile, TransformationResult
 from tests.resource_test_base import ResourceTestBase
 
 
 class TestTransformFileComplete(ResourceTestBase):
-    def test_put_transform_file_complete_files_remaining(self, mocker,  mock_rabbit_adaptor):
+    def _generate_file_complete_request(self):
+        return {
+            'file-path': '/foo/bar.root',
+            'file-id': 42,
+            'status': 'OK',
+            'total-time': 100,
+            'num-messages': 1024,
+            'total-events': 10000,
+            'total-bytes': 325683,
+            'avg-rate': 30.2
+        }
+
+    def test_put_transform_file_complete_files_remaining(self, mocker,
+                                                         mock_rabbit_adaptor):
         import servicex
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
@@ -40,24 +53,24 @@ class TestTransformFileComplete(ResourceTestBase):
             'return_request',
             return_value=self._generate_transform_request())
 
-        mock_files_remaining = mocker.patch.object(TransformRequest, 'files_remaining',
+        mock_files_remaining = mocker.patch.object(TransformRequest,
+                                                   'files_remaining',
                                                    return_value=1)
+
+        mocker.patch.object(DatasetFile, "get_by_id")
+        mocker.patch.object(TransformationResult, "save_to_db")
 
         client = self._test_client(transformation_manager=mock_transformer_manager,
                                    rabbit_adaptor=mock_rabbit_adaptor)
         response = client.put('/servicex/transformation/1234/file-complete',
-                              json={
-                                  'file-path': '/foo/bar.root',
-                                  'status': 'OK',
-                                  'total-time': 100,
-                                  'num-messages': 1024
-                              })
+                              json=self._generate_file_complete_request())
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
         mock_files_remaining.assert_called_with('1234')
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
-    def test_put_transform_file_complete_no_files_remaining(self, mocker,  mock_rabbit_adaptor):
+    def test_put_transform_file_complete_no_files_remaining(self, mocker,
+                                                            mock_rabbit_adaptor):
         import servicex
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
@@ -69,19 +82,19 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_files_remaining = mocker.patch.object(TransformRequest, 'files_remaining',
                                                    return_value=0)
 
+        mocker.patch.object(DatasetFile, "get_by_id")
+        mocker.patch.object(TransformationResult, "save_to_db")
+
         client = self._test_client(transformation_manager=mock_transformer_manager,
                                    rabbit_adaptor=mock_rabbit_adaptor)
         response = client.put('/servicex/transformation/1234/file-complete',
-                              json={
-                                  'file-path': '/foo/bar.root',
-                                  'status': 'OK',
-                                  'total-time': 100,
-                                  'num-messages': 1024
-                              })
+                              json=self._generate_file_complete_request())
+
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
         mock_files_remaining.assert_called_with('1234')
-        mock_transformer_manager.shutdown_transformer_job.assert_called_with('1234', 'my-ws')
+        mock_transformer_manager.shutdown_transformer_job.assert_called_with('1234',
+                                                                             'my-ws')
 
     def test_put_transform_file_complete_unknown_files_remaining(self, mocker,
                                                                  mock_rabbit_adaptor):
@@ -93,19 +106,115 @@ class TestTransformFileComplete(ResourceTestBase):
             'return_request',
             return_value=self._generate_transform_request())
 
-        mock_files_remaining = mocker.patch.object(TransformRequest, 'files_remaining',
+        mock_files_remaining = mocker.patch.object(TransformRequest,
+                                                   'files_remaining',
                                                    return_value=None)
+        mocker.patch.object(DatasetFile, "get_by_id")
+        mocker.patch.object(TransformationResult, "save_to_db")
 
         client = self._test_client(transformation_manager=mock_transformer_manager,
                                    rabbit_adaptor=mock_rabbit_adaptor)
         response = client.put('/servicex/transformation/1234/file-complete',
-                              json={
-                                  'file-path': '/foo/bar.root',
-                                  'status': 'OK',
-                                  'total-time': 100,
-                                  'num-messages': 1024
-                              })
+                              json=self._generate_file_complete_request())
+
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
         mock_files_remaining.assert_called_with('1234')
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+
+    def _generate_dataset_file(self):
+        mock_dataset_file = DatasetFile()
+        mock_dataset_file.adler32 = '123-455'
+        mock_dataset_file.file_size = 0
+        mock_dataset_file.file_events = 0
+        mock_dataset_file.file_path = '/foo/bar.root'
+        mock_dataset_file.request_id = 'BR549'
+        return mock_dataset_file
+
+    def test_file_transform_complete_elasticsearch_files_remain(self, mocker,
+                                                                mock_rabbit_adaptor):
+        import servicex
+        from servicex import ElasticSearchAdapter
+
+        mock_transformer_manager = mocker.MagicMock(TransformerManager)
+        mock_elasticsearch_adapter = mocker.MagicMock(ElasticSearchAdapter)
+        mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
+        mocker.patch.object(
+            servicex.models.TransformRequest,
+            'return_request',
+            return_value=self._generate_transform_request())
+
+        mocker.patch.object(TransformRequest, 'files_remaining',
+                            return_value=1)
+
+        mocker.patch.object(DatasetFile, "get_by_id",
+                            return_value=self._generate_dataset_file())
+        mocker.patch.object(TransformationResult, "save_to_db")
+
+        client = self._test_client(transformation_manager=mock_transformer_manager,
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   elasticsearch_adapter=mock_elasticsearch_adapter)
+        response = client.put('/servicex/transformation/1234/file-complete',
+                              json=self._generate_file_complete_request())
+
+        assert response.status_code == 200
+        mock_elasticsearch_adapter.create_update_request.assert_not_called()
+        call = mock_elasticsearch_adapter.create_update_path.mock_calls[0]
+        record_body = call[1][1]
+        assert record_body['req_id'] == 'BR549'
+        assert record_body['adler32'] == '123-455'
+        assert record_body['file_size'] == 0
+        assert record_body['file_events'] == 0
+        assert record_body['file_path'] == '/foo/bar.root'
+        assert record_body['status'] == 'OK'
+        assert record_body['info'] == 'info'
+        assert record_body['events_served'] == 0
+        assert record_body['retries'] == 0
+
+    def test_file_transform_complete_elasticsearch_no_files_remain(self, mocker,
+                                                                   mock_rabbit_adaptor):
+        import servicex
+        from servicex import ElasticSearchAdapter
+
+        mocker.patch.object(servicex.models.TransformationResult, 'count',
+                            return_value=17)
+
+        mocker.patch.object(DatasetFile, "get_by_id",
+                            return_value=self._generate_dataset_file())
+        mocker.patch.object(TransformationResult, "save_to_db")
+
+        mock_transformer_manager = mocker.MagicMock(TransformerManager)
+        mock_elasticsearch_adapter = mocker.MagicMock(ElasticSearchAdapter)
+
+        mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
+        mocker.patch.object(
+            servicex.models.TransformRequest,
+            'return_request',
+            return_value=self._generate_transform_request())
+
+        mocker.patch.object(TransformRequest, 'files_remaining',
+                            return_value=0)
+
+        client = self._test_client(transformation_manager=mock_transformer_manager,
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   elasticsearch_adapter=mock_elasticsearch_adapter)
+        response = client.put('/servicex/transformation/1234/file-complete',
+                              json=self._generate_file_complete_request())
+
+        assert response.status_code == 200
+        path_call = mock_elasticsearch_adapter.create_update_request.mock_calls[0]
+        record_body = path_call[1][1]
+
+        assert record_body['name'] == 'Transformation Request'
+        assert record_body['description'] == 'Transformation Request'
+        assert record_body['dataset'] == '123-456-789'
+        assert record_body['dataset_size'] == 0
+        assert record_body['dataset_files'] == 17
+        assert record_body['dataset_events'] == 0
+        assert record_body['columns'] == 'electron.eta(), muon.pt()'
+        assert record_body['events'] == 0
+        assert record_body['events_transformed'] == 0
+        assert record_body['events_served'] == 0
+        assert record_body['events_processed'] == 0
+        assert record_body['status'] == 'complete'
+        assert record_body['info'] == ' '

--- a/tests/test_elasticsearch_adaptor.py
+++ b/tests/test_elasticsearch_adaptor.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from servicex.elasticsearch_adaptor import ElasticSearchAdapter
+
+
+class TestElasticSearchAdaptor:
+    def test_init(self, mocker):
+
+        mock_es = mocker.patch('elasticsearch.Elasticsearch')
+        ElasticSearchAdapter('localhost', '9999', 'foo', 'bar')
+        mock_es.assert_called_with(hosts=['localhost:9999'], http_auth=('foo', 'bar'))
+
+    def test_create_update_request(self, mocker):
+        import elasticsearch
+        mock_es = mocker.MagicMock(elasticsearch.Elasticsearch)
+        mocker.patch.object(elasticsearch, 'Elasticsearch', return_value=mock_es)
+        adaptor = ElasticSearchAdapter('localhost', '9999', 'foo', 'bar')
+
+        adaptor.create_update_request("123-456", {
+            'name': 'my-nane',
+            'description': 'this is a test'
+        })
+
+        mock_es.index.assert_called_with(
+            body={
+                'name': 'my-nane',
+                'description': 'this is a test'
+            },
+            index='servicex',
+            id='123-456',
+        )
+
+    def test_create_update_path(self, mocker):
+        import elasticsearch
+        mock_es = mocker.MagicMock(elasticsearch.Elasticsearch)
+        mocker.patch.object(elasticsearch, 'Elasticsearch', return_value=mock_es)
+        adaptor = ElasticSearchAdapter('localhost', '9999', 'foo', 'bar')
+
+        adaptor.create_update_path("123-456", {
+            'name': 'my-nane',
+            'description': 'this is a test'
+        })
+
+        mock_es.index.assert_called_with(
+            body={
+                'name': 'my-nane',
+                'description': 'this is a test'
+            },
+            index='servicex_paths',
+            id='123-456',
+        )


### PR DESCRIPTION
# Problem 
Need to send logging messages to elastic search

This is partial fulfillment of [ServiceX #37](https://github.com/ssl-hep/ServiceX/issues/37)

# Approach
Added elastic search adaptor
Added hooks to post updates to adaptor

Needed more tracking of total number of events and total bytes. This involved more interactions with the database throughout the transform job which highlighted deficiencies with sqlite under load. The switch to Postgres highlighted some database mistakes, such as total bytes not fitting in a regular integer.

Added more elastic search updates throughout the process

