### PR TITLE
Use Kafka Broker Setting

### DIFF
--- a/servicex/resources/transform_start.py
+++ b/servicex/resources/transform_start.py
@@ -63,4 +63,5 @@ class TransformStart(ServiceXResource):
                 namespace=namepsace,
                 x509_secret=x509_secret,
                 result_destination=submitted_request.result_destination,
-                result_format=submitted_request.result_format)
+                result_format=submitted_request.result_format,
+                kafka_broker=submitted_request.kafka_broker)

--- a/tests/resources/test_transformer_start.py
+++ b/tests/resources/test_transformer_start.py
@@ -61,16 +61,18 @@ class TestTransformationStart(ResourceTestBase):
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
 
-        mock_transformer_manager.\
-            launch_transformer_jobs.assert_called_with(image='ssl-hep/foo:latest',
-                                                             request_id='1234',
-                                                             workers=42,
-                                                             chunk_size=1000,
-                                                             rabbitmq_uri='amqp://trans.rabbit',
-                                                             namespace='my-ws',
-                                                             result_destination='kafka',
-                                                             result_format='arrow',
-                                                             x509_secret='my-x509-secret')
+        mock_transformer_manager. \
+            launch_transformer_jobs \
+            .assert_called_with(image='ssl-hep/foo:latest',
+                                request_id='1234',
+                                workers=42,
+                                chunk_size=1000,
+                                rabbitmq_uri='amqp://trans.rabbit',
+                                namespace='my-ws',
+                                result_destination='kafka',
+                                result_format='arrow',
+                                x509_secret='my-x509-secret',
+                                kafka_broker='http://ssl-hep.org.kafka:12345')
 
         mock_kafka_constructor.assert_called_with('http://ssl-hep.org.kafka:12345')
 


### PR DESCRIPTION
# Problem
The transform request JSON document has a property Kafka.broker where the user can provide a url to the Kafka broker they want results streamed to. This is not being picked up and the default value is always being used.

Solves issue ServiceX  #65

# Approach
Added a new argument to the TransformerManager `launch_transformer_jobs` method. If it is not None then a new command line argument is tacked on to the cmd for xaod_branches.py with --brokerlist

