### PR TITLE
Use C++ Code Generator and Transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ coverage.xml
 build/
 dist/
 .cache
-
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 dist/
 .cache
 .pytest_cache/
+.vscode/settings.json

--- a/ServiceXTest.postman_collection.json
+++ b/ServiceXTest.postman_collection.json
@@ -6,7 +6,7 @@
 	},
 	"item": [
 		{
-			"name": "submit transformation",
+			"name": "submit func_adl transformation",
 			"event": [
 				{
 					"listen": "test",
@@ -37,7 +37,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\",\n\t\"columns\": \"Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()\",\n\t\"image\": \"sslhep/servicex-transformer:downloadable\",\n\t\"result-destination\": \"kafka\",\n\t\"kafka\":{\n\t\t\"broker\": \"servicex-kafka-1.slateci.net:19092\"\n\t},\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
+					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\",\n\t\"selection\": \"(call ResultTTree (call Select (call SelectMany (call EventDataset (list 'localds:bogus')) (lambda (list e) (call (attr e 'Jets') 'AntiKt4EMTopoJets'))) (lambda (list j) (/ (call (attr j 'pt')) 1000.0))) (list 'JetPt') 'analysis' 'junk.root')\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:develop\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
 				},
 				"url": {
 					"raw": "{{host}}/servicex/transformation",
@@ -53,7 +53,7 @@
 			"response": []
 		},
 		{
-			"name": "submit transformation to h5",
+			"name": "HTT Flat Ntuple",
 			"event": [
 				{
 					"listen": "test",
@@ -84,7 +84,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\",\n\t\"columns\": \"Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()\",\n\t\"image\": \"sslhep/servicex-transformer:downloadable\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"parquet\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 0\n}\t"
+					"raw": "{\n\t\"did\": \"user.kchoi:user.kchoi.NtupleForServiceX\",\n\t\"tree-name\": \"JET_CategoryReduction_JET_Flavor_Composition__1down\",\n\t\"columns\": \"MUON_MS__1down;2\",\n\t\"image\": \"sslhep/servicex-transformer:nano-aod\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"parquet\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
 				},
 				"url": {
 					"raw": "{{host}}/servicex/transformation",
@@ -131,7 +131,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"did\": \"data17_13TeV:data17_13TeV.periodK.physics_Main.PhysCont.DAOD_STDM7.grp22_v01_p3713\",\n\t\"columns\": \"Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()\",\n\t\"image\": \"sslhep/servicex-transformer:rabbitmq\",\n\t\"messaging-backend\": \"kafka\",\n\t\"kafka-broker\": \"servicex-kafka-1.slateci.net:19092\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 25\n}"
+					"raw": "{\n\t\"did\": \"data17_13TeV:data17_13TeV.periodK.physics_Main.PhysCont.DAOD_STDM7.grp22_v01_p3713\",\n\t\"selection\": \"(call ResultTTree (call Select (call SelectMany (call EventDataset (list 'localds:bogus')) (lambda (list e) (call (attr e 'Jets') 'AntiKt4EMTopoJets'))) (lambda (list j) (/ (call (attr j 'pt')) 1000.0))) (list 'JetPt') 'analysis' 'junk.root')\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:develop\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 100\n}\t"
 				},
 				"url": {
 					"raw": "{{host}}/servicex/transformation",
@@ -384,7 +384,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"timestamp\": '2019-08-16T17:52:39.451950',\n\t\"file_path\": \"root://xcache.mwt2.org:1094//root://dcache-atlas-xrootd.desy.de:1094//pnfs/desy.de/atlas/dq2/atlaslocalgroupdisk/rucio/mc15_13TeV/8a/f1/DAOD_STDM3.05630052._000001.pool.root.1\"\n}"
+					"raw": "{\n\t\"timestamp\": '2019-08-16T17:52:39.451950',\n\t\"file_path\": \"root://xcache.mwt2.org:1094//root://dcache-atlas-xrootd.desy.de:1094//pnfs/desy.de/atlas/dq2/atlaslocalgroupdisk/rucio/mc15_13TeV/8a/f1/DAOD_STDM3.05630052._000001.pool.root.1\",\n        \"file-id\": 12,\n        \"status\": \"done\",\n        \"num-messages\": 100,\n        \"total-time\": 32,\n        \"total-events\": 10000,\n        \"total-bytes\": 3203,\n        \"avg-rate\": 30.3\n}"
 				},
 				"url": {
 					"raw": "{{host}}/servicex/transformation/:request_id/complete",

--- a/app.conf.template
+++ b/app.conf.template
@@ -29,6 +29,8 @@ MINIO_URL = 'localhost:9000'
 MINIO_ACCESS_KEY = 'miniouser'
 MINIO_SECRET_KEY = 'leftfoot1'
 
+CODE_GEN_SERVICE_URL = 'http://localhost:5001'
+
 ELASTIC_SEARCH_LOGGING_ENABLED = False
 ES_HOST = 'host'
 ES_PORT = '9200'

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -30,6 +30,7 @@ import os
 from flask import Flask
 from flask_restful import Api
 
+from servicex.code_gen_adapter import CodeGenAdapter
 from servicex.elasticsearch_adaptor import ElasticSearchAdapter
 from servicex.rabbit_adaptor import RabbitAdaptor
 from servicex.routes import add_routes
@@ -53,7 +54,8 @@ def create_app(test_config=None,
                provided_transformer_manager=None,
                provided_rabbit_adaptor=None,
                provided_object_store=None,
-               provided_elasticsearch_adapter=None):
+               provided_elasticsearch_adapter=None,
+               provided_code_gen_service=None):
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
 
@@ -85,6 +87,11 @@ def create_app(test_config=None,
         else:
             rabbit_adaptor = provided_rabbit_adaptor
 
+        if not provided_code_gen_service:
+            code_gen_service = CodeGenAdapter(app.config['CODE_GEN_SERVICE_URL'])
+        else:
+            code_gen_service = provided_code_gen_service
+
         if 'ELASTIC_SEARCH_LOGGING_ENABLED' in app.config \
                 and app.config['ELASTIC_SEARCH_LOGGING_ENABLED']\
                 and not provided_elasticsearch_adapter:
@@ -112,6 +119,6 @@ def create_app(test_config=None,
             db.create_all()
 
         add_routes(api, transformer_manager, rabbit_adaptor, object_store,
-                   elasticsearch_adaptor)
+                   elasticsearch_adaptor, code_gen_service)
 
     return app

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -88,7 +88,9 @@ def create_app(test_config=None,
             rabbit_adaptor = provided_rabbit_adaptor
 
         if not provided_code_gen_service:
-            code_gen_service = CodeGenAdapter(app.config['CODE_GEN_SERVICE_URL'])
+            code_gen_service = CodeGenAdapter(
+                app.config['CODE_GEN_SERVICE_URL'],
+                transformer_manager)
         else:
             code_gen_service = provided_code_gen_service
 

--- a/servicex/code_gen_adapter.py
+++ b/servicex/code_gen_adapter.py
@@ -43,7 +43,7 @@ class CodeGenAdapter:
 
         if result.status_code != 200:
             msg = result.json['Message']
-            raise BaseException(f'Failed to generate translation code: {msg}')
+            raise ValueError(f'Failed to generate translation code: {msg}')
 
         zipfile = ZipFile(BytesIO(result.content))
         return self.transformer_manager.create_configmap_from_zip(zipfile,

--- a/servicex/code_gen_adapter.py
+++ b/servicex/code_gen_adapter.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import requests
+
+
+class CodeGenAdapter:
+    def __init__(self, code_gen_url):
+        self.code_gen_url = code_gen_url
+
+    def generate_code_for_selection(self, selection):
+        result = requests.post(self.code_gen_url + "/servicex/generated-code",
+                               data=selection)
+
+        if result.status_code != 200:
+            msg = result.json['Message']
+            raise BaseException(f'Failed to generate translation code: {msg}')
+        print(result)

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -70,7 +70,7 @@ class TransformRequest(db.Model):
     total_events = db.Column(db.BigInteger, nullable=True)
     total_bytes = db.Column(db.BigInteger, nullable=True)
     did_lookup_time = db.Column(db.Integer, nullable=True)
-    generated_code_cm = db.Column(db.String(40), nullable=True)
+    generated_code_cm = db.Column(db.String(128), nullable=True)
 
     def save_to_db(self):
         db.session.add(self)

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -47,7 +47,8 @@ class TransformRequest(db.Model):
             'result-destination': x.result_destination,
             'result-format': x.result_format,
             'kafka-broker': x.kafka_broker,
-            'workflow-name': x.workflow_name
+            'workflow-name': x.workflow_name,
+            'generated-code-cm': x.generated_code_cm
         }
 
     id = db.Column(db.Integer, primary_key=True)
@@ -69,6 +70,7 @@ class TransformRequest(db.Model):
     total_events = db.Column(db.BigInteger, nullable=True)
     total_bytes = db.Column(db.BigInteger, nullable=True)
     did_lookup_time = db.Column(db.Integer, nullable=True)
+    generated_code_cm = db.Column(db.String(40), nullable=True)
 
     def save_to_db(self):
         db.session.add(self)

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -40,18 +40,21 @@ class TransformRequest(db.Model):
             'request_id': x.request_id,
             'did': x.did,
             'columns': x.columns,
+            'selection': x.selection,
             'image': x.image,
             'chunk-size': x.chunk_size,
             'workers': x.workers,
             'result-destination': x.result_destination,
             'result-format': x.result_format,
-            'kafka-broker': x.kafka_broker
+            'kafka-broker': x.kafka_broker,
+            'workflow-name': x.workflow_name
         }
 
     id = db.Column(db.Integer, primary_key=True)
     submit_time = db.Column(db.DateTime, nullable=False)
     did = db.Column(db.String(512), unique=False, nullable=False)
-    columns = db.Column(db.String(1024), unique=False, nullable=False)
+    columns = db.Column(db.String(1024), unique=False, nullable=True)
+    selection = db.Column(db.String(1024), unique=False, nullable=True)
     request_id = db.Column(db.String(48), unique=True, nullable=False)
     image = db.Column(db.String(128), nullable=True)
     chunk_size = db.Column(db.Integer, nullable=True)
@@ -59,6 +62,7 @@ class TransformRequest(db.Model):
     result_destination = db.Column(db.String(32), nullable=False)
     result_format = db.Column(db.String(32), nullable=False)
     kafka_broker = db.Column(db.String(128), nullable=True)
+    workflow_name = db.Column(db.String(40), nullable=False)
 
     files = db.Column(db.Integer, nullable=True)
     files_skipped = db.Column(db.Integer, nullable=True)

--- a/servicex/resources/submit_transformation_request.py
+++ b/servicex/resources/submit_transformation_request.py
@@ -56,9 +56,8 @@ kafka_parser.add_argument('broker', required=False, location=('kafka'))
 
 def _workflow_name(transform_request):
     'Look at the keys and determine what sort of a workflow we want to run'
-    has_columns = ('columns' in transform_request) and transform_request['columns'] is not None
-    has_selection = ('selection' in transform_request) \
-        and transform_request['selection'] is not None
+    has_columns = ('columns' in transform_request) and transform_request['columns']
+    has_selection = ('selection' in transform_request) and transform_request['selection']
     if has_columns and not has_selection:
         return 'straight_transform'
     if not has_columns and has_selection:

--- a/servicex/resources/transform_start.py
+++ b/servicex/resources/transform_start.py
@@ -55,6 +55,7 @@ class TransformStart(ServiceXResource):
             rabbitmq_uri = current_app.config['TRANSFORMER_RABBIT_MQ_URL']
             namepsace = current_app.config['TRANSFORMER_NAMESPACE']
             x509_secret = current_app.config['TRANSFORMER_X509_SECRET']
+            generated_code_cm = submitted_request.generated_code_cm
 
             self.transformer_manager.launch_transformer_jobs(
                 image=submitted_request.image, request_id=request_id,
@@ -62,6 +63,7 @@ class TransformStart(ServiceXResource):
                 chunk_size=submitted_request.chunk_size, rabbitmq_uri=rabbitmq_uri,
                 namespace=namepsace,
                 x509_secret=x509_secret,
+                generated_code_cm=generated_code_cm,
                 result_destination=submitted_request.result_destination,
                 result_format=submitted_request.result_format,
                 kafka_broker=submitted_request.kafka_broker)

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -28,7 +28,7 @@
 
 
 def add_routes(api, transformer_manager, rabbit_mq_adaptor,
-               object_store, elasticsearch_adapter):
+               object_store, elasticsearch_adapter, code_gen_service):
     from servicex.resources.submit_transformation_request import SubmitTransformationRequest
     from servicex.resources.transform_start import TransformStart
     from servicex.resources.transform_status import TransformationStatus
@@ -40,7 +40,8 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
 
     SubmitTransformationRequest.make_api(rabbitmq_adaptor=rabbit_mq_adaptor,
                                          object_store=object_store,
-                                         elasticsearch_adapter=elasticsearch_adapter)
+                                         elasticsearch_adapter=elasticsearch_adapter,
+                                         code_gen_service=code_gen_service)
     api.add_resource(SubmitTransformationRequest, '/servicex/transformation')
 
     api.add_resource(QueryTransformationRequest,

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -25,6 +25,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import base64
+
 import kubernetes
 from kubernetes import client
 from flask import current_app
@@ -41,7 +43,8 @@ class TransformerManager:
             raise ValueError('Manager mode '+manager_mode+' not valid')
 
     def create_job_object(self, request_id, image, chunk_size, rabbitmq_uri, workers,
-                          result_destination, result_format, x509_secret, kafka_broker):
+                          result_destination, result_format, x509_secret, kafka_broker,
+                          generated_code_cm):
         volume_mounts = [
             client.V1VolumeMount(
                 name='x509-secret',
@@ -54,6 +57,16 @@ class TransformerManager:
                 secret=client.V1SecretVolumeSource(secret_name=x509_secret)
             )
         ]
+
+        if generated_code_cm:
+            volumes.append(client.V1Volume(
+                name='generated-code',
+                config_map=client.V1ConfigMapVolumeSource(
+                    name=generated_code_cm)
+                )
+            )
+            volume_mounts.append(
+                client.V1VolumeMount(mount_path="/generated", name='generated-code'))
 
         if "TRANSFORMER_LOCAL_PATH" in current_app.config:
             path = current_app.config['TRANSFORMER_LOCAL_PATH']
@@ -125,12 +138,13 @@ class TransformerManager:
         print("Job created. status='%s'" % str(api_response.status))
 
     def launch_transformer_jobs(self, image, request_id, workers, chunk_size,
-                                rabbitmq_uri, namespace, x509_secret,
-                                result_destination, result_format, kafka_broker=None):
+                                rabbitmq_uri, namespace, x509_secret, generated_code_cm,
+                                result_destination, result_format, kafka_broker=None,
+                                ):
         batch_v1 = client.BatchV1Api()
         job = self.create_job_object(request_id, image, chunk_size, rabbitmq_uri, workers,
                                      result_destination, result_format,
-                                     x509_secret, kafka_broker)
+                                     x509_secret, kafka_broker, generated_code_cm)
         self.create_job(batch_v1, job, namespace)
 
     def shutdown_transformer_job(self, request_id, namespace):
@@ -143,3 +157,30 @@ class TransformerManager:
         batch_v1.delete_namespaced_job(name="transformer-" + request_id,
                                        body=body,
                                        namespace=namespace)
+
+    def create_configmap_from_zip(self, zipfile, request_id, namespace):
+        configmap_name = "{}-generated-source".format(request_id)
+        data = {
+            file.filename:
+                base64.b64encode(zipfile.open(file).read()).decode("ascii") for file in
+            zipfile.filelist
+        }
+
+        metadata = client.V1ObjectMeta(
+            name=configmap_name,
+            namespace=namespace,
+        )
+
+        # Instantiate the configmap object
+        configmap = client.V1ConfigMap(
+            api_version="v1",
+            kind="ConfigMap",
+            binary_data=data,
+            metadata=metadata
+        )
+
+        api_instance = client.CoreV1Api()
+        api_instance.create_namespaced_config_map(
+            namespace=namespace,
+            body=configmap)
+        return configmap_name

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -89,14 +89,16 @@ class TransformerManager:
                                 value=current_app.config['MINIO_SECRET_KEY'])
             ]
 
-        python_args = [" --request-id " + request_id +
+        python_args = ["/home/atlas/proxy-exporter.sh & sleep 5 && " +
+                       "python /home/atlas/transformer.py " +
+                       " --request-id " + request_id +
                        " --rabbit-uri " + rabbitmq_uri +
                        " --chunks " + str(chunk_size) +
                        " --result-destination " + result_destination +
                        " --result-format " + result_format]
 
         if kafka_broker:
-            python_args.append(" --brokerlist "+kafka_broker)
+            python_args[0] += " --brokerlist "+kafka_broker
 
         # Configure Pod template container
         container = client.V1Container(
@@ -106,8 +108,7 @@ class TransformerManager:
             volume_mounts=volume_mounts,
             command=["bash", "-c"],
             env=env,
-            args=["/home/atlas/proxy-exporter.sh & sleep 5 && " +
-                  "python xaod_branches.py " + " ".join(python_args)]
+            args=python_args
         )
         # Create and Configure a spec section
         template = client.V1PodTemplateSpec(

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -30,6 +30,7 @@ from pytest import fixture
 from servicex import create_app
 from servicex.models import TransformRequest
 from servicex.rabbit_adaptor import RabbitAdaptor
+from servicex.code_gen_adapter import CodeGenAdapter
 
 
 class ResourceTestBase:
@@ -49,7 +50,8 @@ class ResourceTestBase:
             'OBJECT_STORE_ENABLED': False,
             'MINIO_URL': 'localhost:9000',
             'MINIO_ACCESS_KEY': 'miniouser',
-            'MINIO_SECRET_KEY': 'leftfoot1'
+            'MINIO_SECRET_KEY': 'leftfoot1',
+            'CODE_GEN_SERVICE_URL': 'http://localhost:5001'
         }
 
     @staticmethod
@@ -57,7 +59,8 @@ class ResourceTestBase:
                      transformation_manager=None,
                      rabbit_adaptor=None,
                      object_store=None,
-                     elasticsearch_adapter=None):
+                     elasticsearch_adapter=None,
+                     code_gen_service=None):
         config = ResourceTestBase._app_config()
         config['TRANSFORMER_MANAGER_ENABLED'] = False
         config['TRANSFORMER_MANAGER_MODE'] = 'external'
@@ -66,7 +69,7 @@ class ResourceTestBase:
             config.update(additional_config)
 
         app = create_app(config, transformation_manager, rabbit_adaptor,
-                         object_store, elasticsearch_adapter)
+                         object_store, elasticsearch_adapter, code_gen_service)
 
         return app.test_client()
 
@@ -90,3 +93,7 @@ class ResourceTestBase:
     @fixture
     def mock_rabbit_adaptor(self, mocker):
         return mocker.MagicMock(RabbitAdaptor)
+
+    @fixture
+    def mock_code_gen_service(self, mocker):
+        return mocker.MagicMock(CodeGenAdapter)

--- a/tests/resources/test_query_transformation_request.py
+++ b/tests/resources/test_query_transformation_request.py
@@ -63,6 +63,7 @@ class TestQueryTransformationRequest(ResourceTestBase):
                                  'workers': 42, 'result-destination': 'kafka',
                                  'result-format': 'arrow',
                                  'kafka-broker': 'http://ssl-hep.org.kafka:12345',
-                                 'workflow-name': None}
+                                 'workflow-name': None,
+                                 'generated-code-cm': None}
 
         mock_transform_request_read.assert_called_with('1234')

--- a/tests/resources/test_query_transformation_request.py
+++ b/tests/resources/test_query_transformation_request.py
@@ -58,9 +58,11 @@ class TestQueryTransformationRequest(ResourceTestBase):
         print(response.json)
         assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
                                  'columns': 'electron.eta(), muon.pt()',
+                                 'selection': None,
                                  'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
                                  'workers': 42, 'result-destination': 'kafka',
                                  'result-format': 'arrow',
-                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345'}
+                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
+                                 'workflow-name': None}
 
         mock_transform_request_read.assert_called_with('1234')

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -72,7 +72,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
     def test_submit_transformation_bad_root_format(self, mocker, mock_rabbit_adaptor):
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         request = self._generate_transformation_request()
-        request['result-format'] = 'root-file'
+        request['result-format'] = 'root-fileXX'
         response = client.post('/servicex/transformation', json=request)
         assert response.status_code == 400
 
@@ -143,10 +143,13 @@ class TestSubmitTransformationRequest(ResourceTestBase):
                                                      "service-endpoint": service_endpoint}
                                              ))
 
-    def test_submit_transformation_with_root_file(self, mocker, mock_rabbit_adaptor):
+    def test_submit_transformation_with_root_file(self, mocker,
+                                                  mock_rabbit_adaptor,
+                                                  mock_code_gen_service):
         request = self._generate_transformation_request_xAOD_root_file()
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service)
         response = client.post('/servicex/transformation',
                                json=request)
 
@@ -169,6 +172,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
         setup_queue_calls = [call(request_id), call(request_id+"_errors")]
         mock_rabbit_adaptor.setup_queue.assert_has_calls(setup_queue_calls)
+        mock_code_gen_service.generate_code_for_selection("test-string")
 
         bind_to_exchange_calls = [
             call(exchange="transformation_requests", queue=request_id),

--- a/tests/resources/test_transformer_start.py
+++ b/tests/resources/test_transformer_start.py
@@ -67,6 +67,7 @@ class TestTransformationStart(ResourceTestBase):
                                 request_id='1234',
                                 workers=42,
                                 chunk_size=1000,
+                                generated_code_cm=None,
                                 rabbitmq_uri='amqp://trans.rabbit',
                                 namespace='my-ws',
                                 result_destination='kafka',

--- a/tests/test_code_gen_adapter.py
+++ b/tests/test_code_gen_adapter.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pytest
+
+from servicex.code_gen_adapter import CodeGenAdapter
+
+
+class TestCodeGenAdapter:
+    def test_init(self, mocker):
+        service = CodeGenAdapter("http://foo.com")
+        assert service.code_gen_url == "http://foo.com"
+
+    def test_generate_code_for_selection(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_requests_post = mocker.patch('requests.post', return_value=mock_response)
+        service = CodeGenAdapter("http://foo.com")
+        service.generate_code_for_selection("test-tring")
+        mock_requests_post.assert_called()
+
+    def test_generate_code_bad_response(self, mocker):
+        mock_response = mocker.Mock()
+        mock_response.status_code = 500
+        mock_response.json = {"Message": "Ooops"}
+        mocker.patch('requests.post', return_value=mock_response)
+        service = CodeGenAdapter("http://foo.com")
+
+        with pytest.raises(BaseException) as eek:
+            service.generate_code_for_selection("test-tring")
+        assert str(eek.value) == 'Failed to generate translation code: Ooops'

--- a/tests/test_code_gen_adapter.py
+++ b/tests/test_code_gen_adapter.py
@@ -66,6 +66,6 @@ class TestCodeGenAdapter:
         mock_transformer_manager = mocker.Mock()
         service = CodeGenAdapter("http://foo.com", mock_transformer_manager)
 
-        with pytest.raises(BaseException) as eek:
+        with pytest.raises(ValueError) as eek:
             service.generate_code_for_selection(self._generate_test_request(), "servicex")
         assert str(eek.value) == 'Failed to generate translation code: Ooops'


### PR DESCRIPTION
# Problem
Partial solution to [ServiceX Issue 28](https://github.com/ssl-hep/ServiceX/issues/28)
In order to use the C++ transformer, the incoming request must be sent to the Code Generator and the resulting zip file expanded into a configMap. The launched transformers need to be configured to mount this configMap

# Approach
1. Add a new property to the JSON request, `selection`
2. Introduce the concept of different workflows:
- One for when the columns are included in the request
- A Second one for calling the code generator on the included selection 
3. Add an adaptor to the Code Gen Service
4. Accept a new output format: `root-file`
5. Update the transformer start to mount the config map

The postman tests are updated to demonstrate the use of selections