### PR TITLE
Accept File List in Request

### DIFF
--- a/ServiceXTest.postman_collection.json
+++ b/ServiceXTest.postman_collection.json
@@ -1,12 +1,12 @@
 {
 	"info": {
-		"_postman_id": "9003808e-201a-47d9-bf3a-3f0f715b93c9",
+		"_postman_id": "dc13cd9f-3666-4add-a391-36f5782d3663",
 		"name": "ServiceXTest",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "submit func_adl transformation",
+			"name": "submit with file list",
 			"event": [
 				{
 					"listen": "test",
@@ -31,13 +31,13 @@
 				"header": [
 					{
 						"key": "Content-Type",
-						"value": "application/json",
-						"type": "text"
+						"type": "text",
+						"value": "application/json"
 					}
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\",\n\t\"selection\": \"(call ResultTTree (call Select (call SelectMany (call EventDataset (list 'localds:bogus')) (lambda (list e) (call (attr e 'Jets') 'AntiKt4EMTopoJets'))) (lambda (list j) (/ (call (attr j 'pt')) 1000.0))) (list 'JetPt') 'analysis' 'junk.root')\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:develop\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
+					"raw": "{\n\t\"file-list\":[\n\t\t\t\"root://eospublic-srv-b2.cern.ch:1094//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/W3JetsToLNu.root?eos.share.expires=1581990269&eos.share.fxid=31695bb90000000&eos.share.signature=u6hHlQ/D4+IsLWYwPt70st/6cc65L0Qf+b1F2EFct9nRsWl175zAF0u7NEJklD93S4RosVCmCijxffWhd/qGHPJ+4fK/QgRfysjeaOUFQNo/H9z0rF95p70my8zhMv9Qzq/IW9G6eAoq/mLWive24n7IH2lmAQVK\",\n\t\t\t\"root://eospublic-srv-b2.cern.ch:1094//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/W2JetsToLNu.root?eos.share.expires=1581990341&eos.share.fxid=31695ace0000000&eos.share.signature=CCX9/DjWIioVtqrQLAYze814KZoTQmmDfjXN2K0MN9jLRWQtSmNoafi5XHTbILS6uU/bjSrjJa5k+cDMtAZ/4/hdahl2X6uW9pb5IledK/L15jmYmQTsxFgOqanhRQwcuijYQB1De+pLAJkId/r12Ou0qAeutGNG\",\n\t\t\t\"root://eospublic-srv-b2.cern.ch:1094//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/W3JetsToLNu.root?eos.share.expires=1581990366&eos.share.fxid=31695bb90000000&eos.share.signature=CCX9/DjWIipkd34bs9QCtp1S+lcIsJoDB4Ev/0KgEV14ywZ9Dz66jy6rz8gFrqg4BjE71bOnU58kaSvqlx/rtG91fZD0/ggOB9NBr52p7e3Gj4+s+/R0hT4Ia3qj6CqBO/6YWEi+NGWjgycxuP1qtR9vpjonqzR3\"\n\t\t],\n\t\"columns\": \"MUON_MS__1down;2\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:develop\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
 				},
 				"url": {
 					"raw": "{{host}}/servicex/transformation",
@@ -165,7 +165,7 @@
 					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\",\n\t\"columns\": \"Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()\",\n\t\"image\": \"sslhep/servicex-transformer:rabbitmq\",\n\t\"messaging-backend\": \"kafka\",\n\t\"kafka-broker\": \"servicex-kafka-1.slateci.net:19092\",\n\t\"chunk-size\": 9000,\n\t\"workers\": 100\n}"
 				},
 				"url": {
-					"raw": "{{host}}/servicex/transformation/:request_id",
+					"raw": "{{host}}/servicex/transformation/:request_id?",
 					"host": [
 						"{{host}}"
 					],
@@ -226,7 +226,7 @@
 					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\",\n\t\"columns\": \"Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()\",\n\t\"image\": \"sslhep/servicex-transformer:rabbitmq\",\n\t\"messaging-backend\": \"kafka\",\n\t\"kafka-broker\": \"servicex-kafka-1.slateci.net:19092\",\n\t\"chunk-size\": 9000,\n\t\"workers\": 100\n}"
 				},
 				"url": {
-					"raw": "{{host}}/servicex/transformation",
+					"raw": "{{host}}/servicex/transformation?",
 					"host": [
 						"{{host}}"
 					],
@@ -566,5 +566,6 @@
 			},
 			"response": []
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/ServiceXTest.postman_collection.json
+++ b/ServiceXTest.postman_collection.json
@@ -37,7 +37,54 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"file-list\":[\n\t\t\t\"root://eospublic-srv-b2.cern.ch:1094//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/W3JetsToLNu.root?eos.share.expires=1581990269&eos.share.fxid=31695bb90000000&eos.share.signature=u6hHlQ/D4+IsLWYwPt70st/6cc65L0Qf+b1F2EFct9nRsWl175zAF0u7NEJklD93S4RosVCmCijxffWhd/qGHPJ+4fK/QgRfysjeaOUFQNo/H9z0rF95p70my8zhMv9Qzq/IW9G6eAoq/mLWive24n7IH2lmAQVK\",\n\t\t\t\"root://eospublic-srv-b2.cern.ch:1094//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/W2JetsToLNu.root?eos.share.expires=1581990341&eos.share.fxid=31695ace0000000&eos.share.signature=CCX9/DjWIioVtqrQLAYze814KZoTQmmDfjXN2K0MN9jLRWQtSmNoafi5XHTbILS6uU/bjSrjJa5k+cDMtAZ/4/hdahl2X6uW9pb5IledK/L15jmYmQTsxFgOqanhRQwcuijYQB1De+pLAJkId/r12Ou0qAeutGNG\",\n\t\t\t\"root://eospublic-srv-b2.cern.ch:1094//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/W3JetsToLNu.root?eos.share.expires=1581990366&eos.share.fxid=31695bb90000000&eos.share.signature=CCX9/DjWIipkd34bs9QCtp1S+lcIsJoDB4Ev/0KgEV14ywZ9Dz66jy6rz8gFrqg4BjE71bOnU58kaSvqlx/rtG91fZD0/ggOB9NBr52p7e3Gj4+s+/R0hT4Ia3qj6CqBO/6YWEi+NGWjgycxuP1qtR9vpjonqzR3\"\n\t\t],\n\t\"columns\": \"MUON_MS__1down;2\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:develop\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
+					"raw": "{\n\t\"file-list\":[\n\t\t\t\"root://dcache-atlas-xrootd-wan.desy.de:1094//pnfs/desy.de/atlas/dq2/atlaslocalgroupdisk/rucio/mc15_13TeV/3d/89/DAOD_STDM3.05630052._000005.pool.root.1\",\n\t\t\t \"root://dcache-atlas-xrootd-wan.desy.de:1094//pnfs/desy.de/atlas/dq2/atlaslocalgroupdisk/rucio/mc15_13TeV/91/60/DAOD_STDM3.05630052._000006.pool.root.1\",\n\t\t\t \"root://dcache-atlas-xrootd-wan.desy.de:1094//pnfs/desy.de/atlas/dq2/atlaslocalgroupdisk/rucio/mc15_13TeV/fb/85/DAOD_STDM3.05630052._000007.pool.root.1\"\n\t\t],\n\t\"selection\": \"(call ResultTTree (call Select (call SelectMany (call EventDataset (list 'localds://did_01')) (lambda (list e) (call (attr e 'Jets') ''))) (lambda (list j) (call (attr j 'pt')))) (list 'jet_pt') 'analysis' 'junk.root')\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:v0.2\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
+				},
+				"url": {
+					"raw": "{{host}}/servicex/transformation",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"servicex",
+						"transformation"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "submit with DID",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "12b3c129-2d3c-4bd4-aa5c-e3ee15056a9b",
+						"exec": [
+							"var jsonData = JSON.parse(responseBody);",
+							"postman.setEnvironmentVariable(\"token\", jsonData['request_id']);",
+							"",
+							"// example using pm.response.to.have",
+							"pm.test(\"response is ok\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"did\": \"mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00\"\n\t\"selection\": \"(call ResultTTree (call Select (call SelectMany (call EventDataset (list 'localds://did_01')) (lambda (list e) (call (attr e 'Jets') ''))) (lambda (list j) (call (attr j 'pt')))) (list 'jet_pt') 'analysis' 'junk.root')\",\n\t\"image\": \"sslhep/servicex_xaod_cpp_transformer:develop\",\n\t\"result-destination\": \"object-store\",\n\t\"result-format\": \"root-file\",\n\t\"chunk-size\": 7000,\n\t\"workers\": 1\n}\t"
 				},
 				"url": {
 					"raw": "{{host}}/servicex/transformation",

--- a/servicex/lookup_result_processor.py
+++ b/servicex/lookup_result_processor.py
@@ -27,6 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import json
 
+from servicex.models import TransformRequest
+
 
 class LookupResultProcessor:
     def __init__(self, rabbitmq_adaptor, elasticsearch_adaptor, advertised_endpoint):
@@ -71,3 +73,13 @@ class LookupResultProcessor:
         self.rabbitmq_adaptor.basic_publish(exchange='transformation_requests',
                                             routing_key=request_id,
                                             body=json.dumps(transform_request))
+
+    def report_fileset_complete(self, submitted_request,
+                                num_files, num_skipped=0, total_events=0,
+                                total_bytes=0, did_lookup_time=0):
+        submitted_request.files = num_files
+        submitted_request.files_skipped = num_skipped
+        submitted_request.total_events = total_events
+        submitted_request.total_bytes = total_bytes
+        submitted_request.did_lookup_time = did_lookup_time
+        TransformRequest.update_request(submitted_request)

--- a/servicex/resources/fileset_complete.py
+++ b/servicex/resources/fileset_complete.py
@@ -32,13 +32,19 @@ from servicex.resources.servicex_resource import ServiceXResource
 
 
 class FilesetComplete(ServiceXResource):
+    @classmethod
+    def make_api(cls, lookup_result_processor):
+        cls.lookup_result_processor = lookup_result_processor
+        return cls
+
     def put(self, request_id):
         summary = request.get_json()
         rec = TransformRequest.return_request(request_id)
-        rec.files = summary['files']
-        rec.files_skipped = summary['files-skipped']
-        rec.total_events = summary['total-events']
-        rec.total_bytes = summary['total-bytes']
-        rec.did_lookup_time = summary['elapsed-time']
-        TransformRequest.update_request(rec)
-        print("Complete "+request_id)
+        self.lookup_result_processor.report_fileset_complete(
+            rec,
+            num_files=summary['files'],
+            num_skipped=summary['files-skipped'],
+            total_events=summary['total-events'],
+            total_bytes=summary['total-bytes'],
+            did_lookup_time=summary['elapsed-time']
+        )

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -34,8 +34,8 @@ from servicex.models import TransformationResult
 
 
 class ServiceXResource(Resource):
-    @staticmethod
-    def _generate_advertised_endpoint(endpoint):
+    @classmethod
+    def _generate_advertised_endpoint(cls, endpoint):
         return "http://" + current_app.config['ADVERTISED_HOSTNAME'] + "/" + endpoint
 
     @staticmethod

--- a/servicex/resources/submit_transformation_request.py
+++ b/servicex/resources/submit_transformation_request.py
@@ -165,7 +165,7 @@ class SubmitTransformationRequest(ServiceXResource):
                 self.rabbitmq_adaptor.basic_publish(exchange='',
                                                     routing_key='did_requests',
                                                     body=json.dumps(did_request))
-            elif requested_file_list:
+            else:
                 # Request a preflight check on the first file
                 self.lookup_result_processor.publish_preflight_request(
                     request_rec,

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -51,7 +51,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
 
     api.add_resource(TransformationStatus, '/servicex/transformation/<string:request_id>/status')
 
-    AddFileToDataset.make_api(rabbit_mq_adaptor, elasticsearch_adapter)
+    AddFileToDataset.make_api(lookup_result_processor, elasticsearch_adapter)
     api.add_resource(AddFileToDataset, '/servicex/transformation/<string:request_id>/files')
 
     PreflightCheck.make_api(lookup_result_processor)

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -42,7 +42,8 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     SubmitTransformationRequest.make_api(rabbitmq_adaptor=rabbit_mq_adaptor,
                                          object_store=object_store,
                                          elasticsearch_adapter=elasticsearch_adapter,
-                                         code_gen_service=code_gen_service)
+                                         code_gen_service=code_gen_service,
+                                         lookup_result_processor=lookup_result_processor)
     api.add_resource(SubmitTransformationRequest, '/servicex/transformation')
 
     api.add_resource(QueryTransformationRequest,

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -57,6 +57,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     PreflightCheck.make_api(lookup_result_processor)
     api.add_resource(PreflightCheck, '/servicex/transformation/<string:request_id>/preflight')
 
+    FilesetComplete.make_api(lookup_result_processor)
     api.add_resource(FilesetComplete, '/servicex/transformation/<string:request_id>/complete')
 
     TransformStart.make_api(transformer_manager)

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -28,7 +28,8 @@
 
 
 def add_routes(api, transformer_manager, rabbit_mq_adaptor,
-               object_store, elasticsearch_adapter, code_gen_service):
+               object_store, elasticsearch_adapter, code_gen_service,
+               lookup_result_processor):
     from servicex.resources.submit_transformation_request import SubmitTransformationRequest
     from servicex.resources.transform_start import TransformStart
     from servicex.resources.transform_status import TransformationStatus
@@ -53,7 +54,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     AddFileToDataset.make_api(rabbit_mq_adaptor, elasticsearch_adapter)
     api.add_resource(AddFileToDataset, '/servicex/transformation/<string:request_id>/files')
 
-    PreflightCheck.make_api(rabbit_mq_adaptor)
+    PreflightCheck.make_api(lookup_result_processor)
     api.add_resource(PreflightCheck, '/servicex/transformation/<string:request_id>/preflight')
 
     api.add_resource(FilesetComplete, '/servicex/transformation/<string:request_id>/complete')

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -60,7 +60,8 @@ class ResourceTestBase:
                      rabbit_adaptor=None,
                      object_store=None,
                      elasticsearch_adapter=None,
-                     code_gen_service=None):
+                     code_gen_service=None,
+                     lookup_result_processor=None):
         config = ResourceTestBase._app_config()
         config['TRANSFORMER_MANAGER_ENABLED'] = False
         config['TRANSFORMER_MANAGER_MODE'] = 'external'
@@ -69,7 +70,8 @@ class ResourceTestBase:
             config.update(additional_config)
 
         app = create_app(config, transformation_manager, rabbit_adaptor,
-                         object_store, elasticsearch_adapter, code_gen_service)
+                         object_store, elasticsearch_adapter, code_gen_service,
+                         lookup_result_processor)
 
         return app.test_client()
 

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -196,12 +196,54 @@ class TestSubmitTransformationRequest(ResourceTestBase):
                                                      "service-endpoint": service_endpoint}
                                              ))
 
+    def test_submit_transformation_file_list(self, mocker,
+                                             mock_rabbit_adaptor,
+                                             mock_code_gen_service):
+        request = self._generate_transformation_request()
+        request['did'] = None
+        request['file-list'] = ["file1", "file2"]
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service)
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 200
+
     def test_submit_transformation_with_root_file_selection_error(self, mocker,
                                                                   mock_rabbit_adaptor,
                                                                   mock_code_gen_service):
         mock_code_gen_service.generate_code_for_selection = \
                 mocker.Mock(side_effect=ValueError('This is the error message'))
         request = self._generate_transformation_request_xAOD_root_file()
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service)
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 400
+
+    def test_submit_transformation_missing_dataset_source(self, mocker,
+                                                          mock_rabbit_adaptor,
+                                                          mock_code_gen_service):
+        request = self._generate_transformation_request()
+        request['did'] = None
+        request['file-list'] = []
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service)
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 400
+
+    def test_submit_transformation_duplicate_dataset_source(self, mocker,
+                                                            mock_rabbit_adaptor,
+                                                            mock_code_gen_service):
+        request = self._generate_transformation_request()
+        request['did'] = "This did"
+        request['file-list'] = ["amd this file"]
 
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
                                    code_gen_service=mock_code_gen_service)

--- a/tests/test_lookup_result_processor.py
+++ b/tests/test_lookup_result_processor.py
@@ -28,6 +28,7 @@
 import json
 
 from servicex.lookup_result_processor import LookupResultProcessor
+from servicex.models import DatasetFile
 from tests.resource_test_base import ResourceTestBase
 
 
@@ -45,4 +46,59 @@ class TestLookupResutProcessor(ResourceTestBase):
                  "columns": 'electron.eta(), muon.pt()',
                  "file-path": "root1.root",
                  "service-endpoint": "http://foo.com/servicex/transformation/BR549"
+                 }))
+
+    def test_add_file_to_dataset(self, mocker, mock_rabbit_adaptor):
+        processor = LookupResultProcessor(mock_rabbit_adaptor,
+                                          None, "http://cern.analysis.ch:5000/")
+        dataset_file = DatasetFile(request_id="BR549",
+                                   file_path="/foo/bar.root",
+                                   adler32='12345',
+                                   file_size=1024,
+                                   file_events=500)
+
+        request = self._generate_transform_request()
+        request.result_destination = 'object-store'
+        dataset_file.id = 42
+        dataset_file.save_to_db = mocker.Mock()
+        processor.add_file_to_dataset(request, dataset_file)
+
+        dataset_file.save_to_db.assert_called()
+        mock_rabbit_adaptor.basic_publish.assert_called_with(
+            exchange='transformation_requests',
+            routing_key='BR549',
+            body=json.dumps(
+                {"request-id": 'BR549',
+                 "file-id": 42,
+                 "columns": 'electron.eta(), muon.pt()',
+                 "file-path": "/foo/bar.root",
+                 "service-endpoint": "http://cern.analysis.ch:5000/servicex/transformation/BR549",
+                 'result-destination': 'object-store'
+                 }))
+
+    def test_add_file_to_dataset_kafka(self, mocker, mock_rabbit_adaptor):
+        processor = LookupResultProcessor(mock_rabbit_adaptor,
+                                          None, "http://cern.analysis.ch:5000/")
+        dataset_file = DatasetFile(request_id="BR549",
+                                   file_path="/foo/bar.root",
+                                   adler32='12345',
+                                   file_size=1024,
+                                   file_events=500)
+
+        dataset_file.id = 42
+        dataset_file.save_to_db = mocker.Mock()
+        processor.add_file_to_dataset(self._generate_transform_request(), dataset_file)
+
+        dataset_file.save_to_db.assert_called()
+        mock_rabbit_adaptor.basic_publish.assert_called_with(
+            exchange='transformation_requests',
+            routing_key='BR549',
+            body=json.dumps(
+                {"request-id": 'BR549',
+                 "file-id": 42,
+                 "columns": 'electron.eta(), muon.pt()',
+                 "file-path": "/foo/bar.root",
+                 "service-endpoint": "http://cern.analysis.ch:5000/servicex/transformation/BR549",
+                 'result-destination': 'kafka',
+                 'kafka-broker': 'http://ssl-hep.org.kafka:12345'
                  }))

--- a/tests/test_lookup_result_processor.py
+++ b/tests/test_lookup_result_processor.py
@@ -102,3 +102,21 @@ class TestLookupResutProcessor(ResourceTestBase):
                  'result-destination': 'kafka',
                  'kafka-broker': 'http://ssl-hep.org.kafka:12345'
                  }))
+
+    def test_report_fileset_complete(self, mocker, mock_rabbit_adaptor):
+        import servicex
+        mock_update = mocker.patch.object(servicex.models.TransformRequest, "update_request")
+        processor = LookupResultProcessor(mock_rabbit_adaptor,
+                                          None, "http://cern.analysis.ch:5000/")
+
+        processor.report_fileset_complete(self._generate_transform_request(),
+                                          num_files=1, num_skipped=2,
+                                          total_events=3, total_bytes=4,
+                                          did_lookup_time=5)
+        mock_update.assert_called()
+        args = mock_update.call_args
+        assert args[0][0].files == 1
+        assert args[0][0].files_skipped == 2
+        assert args[0][0].total_events == 3
+        assert args[0][0].total_bytes == 4
+        assert args[0][0].did_lookup_time == 5

--- a/tests/test_rabbit_adaptor.py
+++ b/tests/test_rabbit_adaptor.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pika
+
+from servicex.rabbit_adaptor import RabbitAdaptor
+from tests.resource_test_base import ResourceTestBase
+
+
+class TestRabbitAdaptor(ResourceTestBase):
+    def test_connect(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_pika = mocker.patch('pika.BlockingConnection')
+            rabbit = RabbitAdaptor("amqp://test.com")
+            rabbit.connect()
+            mock_pika.assert_called_with(pika.URLParameters("amqp://test.com"))
+
+    def test_setup_queue(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_declare = mocker.Mock()
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+            # rabbit.connect()
+            rabbit.setup_queue("my_queue")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.queue_declare.assert_called_with(queue="my_queue")
+
+            # Verify that second call doesn't open channel again
+            mock_connection.channel.reset_mock()
+            rabbit.setup_queue("my_queue")
+            mock_connection.channel.assert_not_called()
+
+    def test_setup_queue_broker_closed(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_declare = mocker.Mock(
+                side_effect=pika.exceptions.ConnectionClosedByBroker(1, "u-oh"))
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+            rabbit.setup_queue("my_queue")
+
+    def test_setup_queue_wrong_state(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_declare = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.ChannelWrongStateError,
+                    "ok"
+                ]
+            )
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+            rabbit.setup_queue("my_queue")
+
+            mock_connection.channel.assert_called()
+            assert mock_pika.call_count == 2  # Retried the connection
+
+    def test_setup_queue_connection_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_declare = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPConnectionError,
+                    "ok"
+                ]
+            )
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+            rabbit.setup_queue("my_queue")
+
+            mock_connection.channel.assert_called()
+            assert mock_pika.call_count == 2  # Retried the connection
+
+    def test_bind_queue_to_exchange(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock()
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.bind_queue_to_exchange("exchange1", "my_queue")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.queue_bind.assert_called_with(
+                exchange="exchange1",
+                queue="my_queue",
+                routing_key='my_queue')
+
+    def test_bind_queue_to_exchange_connection_closed(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.ConnectionClosedByBroker(1, "uh-oh"),
+                    "ok"
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.bind_queue_to_exchange("exchange1", "my_queue")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.queue_bind.assert_called_with(
+                exchange="exchange1",
+                queue="my_queue",
+                routing_key='my_queue')
+            assert mock_channel.queue_bind.call_count == 2
+            assert mock_pika.call_count == 1  # No retry
+
+    def test_bind_queue_to_exchange_channel_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPChannelError,
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.bind_queue_to_exchange("exchange1", "my_queue")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.queue_bind.assert_called_with(
+                exchange="exchange1",
+                queue="my_queue",
+                routing_key='my_queue')
+            assert mock_channel.queue_bind.call_count == 1
+            assert mock_pika.call_count == 1  # No retry
+
+    def test_bind_queue_to_exchange_connection_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock()
+            mock_channel.queue_bind = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPConnectionError,
+                    "ok"
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.bind_queue_to_exchange("exchange1", "my_queue")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.queue_bind.assert_called_with(
+                exchange="exchange1",
+                queue="my_queue",
+                routing_key='my_queue')
+            assert mock_channel.queue_bind.call_count == 2
+            assert mock_pika.call_count == 2  # Retried the connection
+
+    def test_basic_publish(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.basic_publish = mocker.Mock()
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.basic_publish("exchange1", "my_queue", "{my: body}")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.basic_publish.assert_called_with(
+                exchange="exchange1",
+                routing_key='my_queue',
+                body="{my: body}")
+
+    def test_basic_publish_connection_closed(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.basic_publish = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.ConnectionClosedByBroker(1, "uh-oh"),
+                    "ok"
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.basic_publish("exchange1", "my_queue", "{my: body}")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            assert mock_channel.basic_publish.call_count == 2
+            assert mock_pika.call_count == 1  # No retry of connection
+
+    def test_basic_publish_channel_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.basic_publish = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPChannelError
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.basic_publish("exchange1", "my_queue", "{my: body}")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            assert mock_channel.basic_publish.call_count == 1
+            assert mock_pika.call_count == 1  # No retry of connection
+
+    def test_basic_publish_connection_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.basic_publish = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPConnectionError,
+                    "ok"
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.basic_publish("exchange1", "my_queue", "{my: body}")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            assert mock_channel.basic_publish.call_count == 2
+            assert mock_pika.call_count == 2
+
+    def test_setup_exchange(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.exchange_declare = mocker.Mock()
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.setup_exchange("exchange1")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            mock_channel.exchange_declare.assert_called_with(
+                exchange="exchange1")
+
+    def test_setup_exchange_connection_closed(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.exchange_declare = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.ConnectionClosedByBroker(1, "uh-oh"),
+                    "ok"
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.setup_exchange("exchange1")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            assert mock_channel.exchange_declare.call_count == 2
+            assert mock_pika.call_count == 2
+
+    def test_setup_exchange_channel_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.exchange_declare = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPChannelError
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.setup_exchange("exchange1")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            assert mock_channel.exchange_declare.call_count == 1
+            assert mock_pika.call_count == 1  # No retry of connection
+
+    def test_setup_exchange_connection_error(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.exchange_declare = mocker.Mock(
+                side_effect=[
+                    pika.exceptions.AMQPConnectionError,
+                    "ok"
+                ]
+            )
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            rabbit.setup_exchange("exchange1")
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+            assert mock_channel.exchange_declare.call_count == 2
+            assert mock_pika.call_count == 2
+
+    def test_close_channel(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_channel = mocker.Mock()
+            mock_channel.close = mocker.Mock()
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            # If channel not open then do nothing
+            rabbit.close_channel()
+            mock_channel.close.assert_not_called()
+
+            rabbit.channel
+            rabbit.close_channel()
+            mock_channel.close.assert_called()
+
+    def test_close_connection(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_connection.close = mocker.Mock()
+
+            mock_channel = mocker.Mock()
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            # If channel not open then do nothing
+            rabbit.close_connection()
+            mock_connection.close.assert_not_called()
+
+            rabbit.channel
+            rabbit.close_connection()
+            mock_connection.close.assert_called()
+
+    def test_channel_acessro(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        with client.application.app_context():
+            mock_connection = mocker.Mock()
+            mock_connection.close = mocker.Mock()
+
+            mock_channel = mocker.Mock()
+
+            mock_connection.channel = mocker.Mock(return_value=mock_channel)
+            mock_pika = mocker.patch('pika.BlockingConnection', return_value=mock_connection)
+            mock_pika.channel = mocker.Mock()
+            rabbit = RabbitAdaptor("amqp://test.com")
+
+            assert rabbit.channel == mock_channel
+            mock_pika.assert_called()
+            mock_connection.channel.assert_called()
+
+            # Test that subsequent call doesn't open a new channel
+            mock_pika.reset_mock()
+            mock_connection.reset_mock()
+            assert rabbit.channel == mock_channel
+            mock_pika.assert_not_called()
+            mock_connection.assert_not_called()


### PR DESCRIPTION
# Problem
Users may wish to bypass DID finder and supply a list of Root file URLs directly in the request
Solves [ServiceX Issue 90](https://github.com/ssl-hep/ServiceX/issues/90)

# Approach
1. Added a new property to the transform request: `file-list`
2. Made `did` property optional. You must provide one or the other, but not both
3. Created a new class `lookup_result_processor` to handle adding files, submitting a preflight check request, and recording the total size of the dataset.
4. Migrated that functionality out of the flask resources 
5. Use that functionality to implement the file list processing
6. Updated postman collection

While I was at it, I improved code coverage by writing some tests for the rabbit_mq_adaptor