### PR TITLE
Expand the size of the select column to handle big queries

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -56,7 +56,8 @@ class TransformRequest(db.Model):
     submit_time = db.Column(db.DateTime, nullable=False)
     did = db.Column(db.String(512), unique=False, nullable=False)
     columns = db.Column(db.String(1024), unique=False, nullable=True)
-    selection = db.Column(db.String(1024), unique=False, nullable=True)
+    max_string_size = 10485760
+    selection = db.Column(db.String(max_string_size), unique=False, nullable=True)
     tree_name = db.Column(db.String(512), unique=False, nullable=True)
     request_id = db.Column(db.String(48), unique=True, nullable=False)
     image = db.Column(db.String(128), nullable=True)


### PR DESCRIPTION
# Problem
The selection column in the database was set to 1024 which is too small for realistic queries

# Approach
Changed the size to the max varcher in Postgres