### PR TITLE
Add retries to RabbitMQ connection

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -13,9 +13,9 @@ JWT_SECRET_KEY = 'jwt-secret-string'
 RABBIT_MQ_URL= 'amqp://user:leftfoot1@localhost:30672/%2F'
 TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:leftfoot1@host.docker.internal:30672/%2F?heartbeat=9000'
 
-# Keep retrying every five seconds for two minutes before giving up
-RABBIT_RETRIES = 24
-RABBIT_RETRY_INTERVAL = 5
+# Keep retrying every ten seconds for two minutes before giving up
+RABBIT_RETRIES = 12
+RABBIT_RETRY_INTERVAL = 10
 
 
 # This will be mounted into the transformer pod's /data directory

--- a/app.conf.template
+++ b/app.conf.template
@@ -13,6 +13,11 @@ JWT_SECRET_KEY = 'jwt-secret-string'
 RABBIT_MQ_URL= 'amqp://user:leftfoot1@localhost:30672/%2F'
 TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:leftfoot1@host.docker.internal:30672/%2F?heartbeat=9000'
 
+# Keep retrying every five seconds for two minutes before giving up
+RABBIT_RETRIES = 24
+RABBIT_RETRY_INTERVAL = 5
+
+
 # This will be mounted into the transformer pod's /data directory
 TRANSFORMER_LOCAL_PATH="/Users/bengal1/dev/IRIS-HEP/data"
 TRANSFORMER_NAMESPACE="default"

--- a/boot.sh
+++ b/boot.sh
@@ -2,4 +2,4 @@
 mkdir instance
 #flask db upgrade
 #flask translate compile
-exec gunicorn -b :5000 --workers=10 --threads=2 --access-logfile - --error-logfile - "servicex:create_app()"
+exec gunicorn -b :5000 --workers=10 --threads=2 --timeout 120 --access-logfile - --error-logfile - "servicex:create_app()"

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -27,6 +27,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import time
+
+import pika
 from flask import Flask
 from flask_restful import Api
 
@@ -39,15 +42,31 @@ from servicex.transformer_manager import TransformerManager
 from servicex.object_store_manager import ObjectStoreManager
 
 
-def _init_rabbit_mq(rabbitmq_url):
-    rabbit_mq_adaptor = RabbitAdaptor(rabbitmq_url)
-    rabbit_mq_adaptor.connect()
+def _init_rabbit_mq(rabbitmq_url, retries, retry_interval):
+    rabbit_mq_adaptor = None
+    retry_count = 0
+    while not rabbit_mq_adaptor:
+        try:
+            rabbit_mq_adaptor = RabbitAdaptor(rabbitmq_url)
+            rabbit_mq_adaptor.connect()
 
-    # Insure the required queues and exchange exist in RabbitMQ broker
-    rabbit_mq_adaptor.setup_queue('did_requests')
-    rabbit_mq_adaptor.setup_queue('validation_requests')
-    rabbit_mq_adaptor.setup_exchange('transformation_requests')
-    rabbit_mq_adaptor.setup_exchange('transformation_failures')
+            # Insure the required queues and exchange exist in RabbitMQ broker
+            rabbit_mq_adaptor.setup_queue('did_requests')
+            rabbit_mq_adaptor.setup_queue('validation_requests')
+            rabbit_mq_adaptor.setup_exchange('transformation_requests')
+            rabbit_mq_adaptor.setup_exchange('transformation_failures')
+
+        except pika.exceptions.AMQPConnectionError as eek:
+            rabbit_mq_adaptor = None
+            retry_count += 1
+            if retry_count < retries:
+                print("Failed to connect to RabbitMQ. Waiting before trying again")
+                time.sleep(retry_interval)
+            else:
+                print("Failed to connect to RabbitMQ. Giving Up")
+                raise eek
+
+    print("Connection to RabbitMQ Adaptor Up")
     return rabbit_mq_adaptor
 
 
@@ -85,7 +104,9 @@ def create_app(test_config=None,
             transformer_manager = provided_transformer_manager
 
         if not provided_rabbit_adaptor:
-            rabbit_adaptor = _init_rabbit_mq(app.config['RABBIT_MQ_URL'])
+            rabbit_adaptor = _init_rabbit_mq(app.config['RABBIT_MQ_URL'],
+                                             app.config['RABBIT_RETRIES'],
+                                             app.config['RABBIT_RETRY_INTERVAL'])
         else:
             rabbit_adaptor = provided_rabbit_adaptor
 


### PR DESCRIPTION
# Problem
When the app starts if the RabbitMQ server is not up it throws an exception and dies. This happens frequently with the helm chart since the RabbitMQ server takes up to a minute to launch. Kubernetes eventually sorts it out with the Crash Loop Retry mechanism, but it's slow and awkward.
Partial Solution to ServiceX [Issue 11](https://github.com/ssl-hep/ServiceX/issues/114)

# Approach
- Added new config entries for max number of retries and number of retry attempts before giving up.
- Added the loop to the Rabbit connect method

# How to Test
Deploy this using the helm chart, observe the log files during RabbitMQ startup

