### PR TITLE
Fix missing function call in json()

### DIFF
--- a/servicex/code_gen_adapter.py
+++ b/servicex/code_gen_adapter.py
@@ -42,7 +42,7 @@ class CodeGenAdapter:
                                data=request_record.selection)
 
         if result.status_code != 200:
-            msg = result.json['Message']
+            msg = result.json()['Message']
             raise ValueError(f'Failed to generate translation code: {msg}')
 
         zipfile = ZipFile(BytesIO(result.content))

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'pytest>=3.6',
+            'pytest>=5.2',
             'pytest-flask',
             'coverage',
             'pytest-mock',

--- a/tests/test_code_gen_adapter.py
+++ b/tests/test_code_gen_adapter.py
@@ -61,7 +61,7 @@ class TestCodeGenAdapter:
     def test_generate_code_bad_response(self, mocker):
         mock_response = mocker.Mock()
         mock_response.status_code = 500
-        mock_response.json = {"Message": "Ooops"}
+        mock_response.json = mocker.Mock(return_value={"Message": "Ooops"})
         mocker.patch('requests.post', return_value=mock_response)
         mock_transformer_manager = mocker.Mock()
         service = CodeGenAdapter("http://foo.com", mock_transformer_manager)


### PR DESCRIPTION
# Problem
The error handler for the code get service was using `result.json` like a property, when it is a function

#Approach
Fixed test to demonstrate this and then fixed the bug 