### PR TITLE
Autoscale Transformer Pods

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -32,6 +32,11 @@ TRANSFORMER_X509_SECRET="aspiring-mole-x509-proxy"
 ADVERTISED_HOSTNAME= 'host.docker.internal:5000'
 
 TRANSFORMER_MANAGER_ENABLED = True
+
+# Set to True to use transformer pod autoscaling. If False then it will always
+# start the requested number of transformers
+TRANSFORMER_AUTOSCALE_ENABLED = True
+
 TRANSFORMER_MANAGER_MODE = 'external-kubernetes'
 
 TRANSFORMER_MESSAGING = 'none'

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -110,6 +110,9 @@ class TransformerManager:
         if kafka_broker:
             python_args[0] += " --brokerlist "+kafka_broker
 
+        resources = client.V1ResourceRequirements(
+            limits={"cpu": 1}
+        )
         # Configure Pod template container
         container = client.V1Container(
             name="transformer-" + request_id,
@@ -118,7 +121,8 @@ class TransformerManager:
             volume_mounts=volume_mounts,
             command=["bash", "-c"],  # Can't get bash to pick up my .bashrc!
             env=env,
-            args=python_args
+            args=python_args,
+            resources=resources
         )
 
         # Create and Configure a spec section

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -45,6 +45,7 @@ class ResourceTestBase:
             'TRANSFORMER_RABBIT_MQ_URL': "amqp://trans.rabbit",
             'TRANSFORMER_NAMESPACE': "my-ws",
             'TRANSFORMER_MANAGER_ENABLED': False,
+            'TRANSFORMER_AUTOSCALE_ENABLED': True,
             'ADVERTISED_HOSTNAME': 'cern.analysis.ch:5000',
             'TRANSFORMER_PULL_POLICY': 'Always',
             'OBJECT_STORE_ENABLED': False,

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -59,8 +59,10 @@ class TestTransformerManager(ResourceTestBase):
 
     def test_init_invalid_config(self, mocker):
         import kubernetes
-        mock_kubernetes_inside = mocker.patch.object(kubernetes.config, 'load_incluster_config')
-        mock_kubernetes_outside = mocker.patch.object(kubernetes.config, 'load_kube_config')
+        mock_kubernetes_inside = mocker.patch.object(kubernetes.config,
+                                                     'load_incluster_config')
+        mock_kubernetes_outside = mocker.patch.object(kubernetes.config,
+                                                      'load_kube_config')
 
         with pytest.raises(ValueError):
             TransformerManager('foo')
@@ -73,6 +75,9 @@ class TestTransformerManager(ResourceTestBase):
         mocker.patch.object(kubernetes.config, 'load_kube_config')
         mock_kubernetes = mocker.patch.object(kubernetes.client, 'AppsV1Api')
 
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
+
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
                                    rabbit_adaptor=mock_rabbit_adaptor)
@@ -84,7 +89,7 @@ class TestTransformerManager(ResourceTestBase):
                 result_destination='kafka', result_format='arrow', x509_secret='x509',
                 generated_code_cm=None)
             called_deployment = mock_kubernetes.mock_calls[1][2]['body']
-            assert called_deployment.spec.replicas == 17
+            assert called_deployment.spec.replicas == 1
             assert len(called_deployment.spec.template.spec.containers) == 1
             container = called_deployment.spec.template.spec.containers[0]
             assert container.image == 'sslhep/servicex-transformer:pytest'
@@ -96,12 +101,20 @@ class TestTransformerManager(ResourceTestBase):
             assert _arg_value(args, '--result-destination') == 'kafka'
 
             assert mock_kubernetes.mock_calls[1][2]['namespace'] == 'my-ns'
+            mock_autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_called()
+            autoscaling_spec = mock_autoscaling.mock_calls[0][2]['body'].spec
+            assert autoscaling_spec.max_replicas == 17
+            assert autoscaling_spec.scale_target_ref.name == 'transformer-1234'
 
     def test_launch_transformer_with_hostpath(self, mocker, mock_rabbit_adaptor):
         import kubernetes
 
         mocker.patch.object(kubernetes.config, 'load_kube_config')
         mock_kubernetes = mocker.patch.object(kubernetes.client, 'AppsV1Api')
+
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
+
         additional_config = {
             'TRANSFORMER_LOCAL_PATH': '/tmp/foo'
         }
@@ -126,11 +139,14 @@ class TestTransformerManager(ResourceTestBase):
             assert container.volume_mounts[1].mount_path == '/data'
             assert called_job.spec.template.spec.volumes[1].host_path.path == '/tmp/foo'
 
-    def test_launch_transformer_jobs_with_generated_code(self, mocker, mock_rabbit_adaptor):
+    def test_launch_transformer_jobs_with_generated_code(self, mocker,
+                                                         mock_rabbit_adaptor):
         import kubernetes
 
         mocker.patch.object(kubernetes.config, 'load_kube_config')
         mock_kubernetes = mocker.patch.object(kubernetes.client, 'AppsV1Api')
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
 
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
@@ -158,6 +174,8 @@ class TestTransformerManager(ResourceTestBase):
 
         mocker.patch.object(kubernetes.config, 'load_kube_config')
         mock_kubernetes = mocker.patch.object(kubernetes.client, 'AppsV1Api')
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
 
         transformer = TransformerManager('external-kubernetes')
         my_config = {
@@ -195,6 +213,9 @@ class TestTransformerManager(ResourceTestBase):
         mocker.patch.object(kubernetes.config, 'load_kube_config')
         mock_kubernetes = mocker.patch.object(kubernetes.client, 'AppsV1Api')
 
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
+
         transformer = TransformerManager('external-kubernetes')
 
         client = self._test_client(transformation_manager=transformer,
@@ -215,15 +236,23 @@ class TestTransformerManager(ResourceTestBase):
 
     def test_shutdown_transformer_jobs(self, mocker, mock_rabbit_adaptor):
         import kubernetes
+
         mocker.patch.object(kubernetes.config, 'load_kube_config')
         mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
         mocker.patch.object(kubernetes.client, 'AppsV1Api',
                             return_value=mock_api)
 
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
+
         transformer = TransformerManager('external-kubernetes')
         transformer.shutdown_transformer_job('1234', 'my-ns')
         mock_api.delete_namespaced_deployment.assert_called_with(name='transformer-1234',
                                                                  namespace='my-ns')
+
+        mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.assert_called_with(
+            name='transformer-1234',
+            namespace='my-ns')
 
     def test_create_configmap_from_zip(self, mocker):
         import kubernetes
@@ -249,7 +278,8 @@ class TestTransformerManager(ResourceTestBase):
         mock_create_namespaced_config_map.assert_called()
         calls = mock_create_namespaced_config_map.call_args
         "foo.sh" in calls[1]['body'].binary_data.keys()
-        assert calls[1]['body'].binary_data['foo.sh'] == \
-            base64.b64encode(b"hi there").decode("ascii")
+        assert calls[1]['body'].binary_data['foo.sh'] == base64.\
+            b64encode(b"hi there").\
+            decode("ascii")
         assert calls[1]['namespace'] == 'servicex'
         assert calls[1]['body'].metadata.name == 'my-request-generated-source'


### PR DESCRIPTION
# Problem
Slow dataset lookups, poorly specified transform requests, and I/O bottlenecks can create conditions where transformers are sitting idle and wasting compute resources.

This is partial solution to [ServiceX Issue 53](https://github.com/ssl-hep/ServiceX/issues/53)

# Approach
Kubernetes offers the horizontal pod autoscaler as a way to scale up the number of pods dedicated to a task based on CPU utilization. The Autoscaler can only be applied to Kubernetes Deployments and not to Jobs.

1. Migrate the transformer manager to launch the transformers as a deployment instead of as a job
2. Add the autoscaler with the generated deployment as the target
3. Update app.config to make autoscaler use optional

# How To Test
Use the unit tests to verify the app in isolation.
See the PR for the Helm chart to see  how to perform integration test
