### PR TITLE
146 minio url in status

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -49,6 +49,9 @@ MINIO_URL = 'localhost:9000'
 MINIO_ACCESS_KEY = 'miniouser'
 MINIO_SECRET_KEY = 'leftfoot1'
 
+# Will be shared with the client so they can find the minio endpoint
+MINIO_PUBLIC_URL = 'localhost:9000'
+
 CODE_GEN_SERVICE_URL = 'http://localhost:5001'
 
 ELASTIC_SEARCH_LOGGING_ENABLED = False

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -101,6 +101,8 @@ class UserModel(db.Model):
 
 class TransformRequest(db.Model):
     __tablename__ = 'requests'
+    OBJECT_STORE_DEST = 'object-store'
+    KAFKA_DEST = 'kafka'
 
     _cache = {}
 

--- a/servicex/resources/query_transformation_request.py
+++ b/servicex/resources/query_transformation_request.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from flask_jwt_extended import jwt_optional
+from flask import current_app
 
 from servicex.models import TransformRequest
 from servicex.resources.servicex_resource import ServiceXResource
@@ -39,8 +40,13 @@ class QueryTransformationRequest(ServiceXResource):
             return {'message': f'Authentication Failed: {str(auth_reject_message)}'}, 401
 
         if request_id:
-            return TransformRequest.to_json(
-                TransformRequest.return_request(request_id)
-            )
+            request_rec = TransformRequest.to_json(
+                TransformRequest.return_request(request_id))
+
+            if current_app.config['OBJECT_STORE_ENABLED']:
+                request_rec['minio-endpoint'] = current_app.config['MINIO_PUBLIC_URL']
+                request_rec['minio-access-key'] = current_app.config['MINIO_ACCESS_KEY']
+                request_rec['minio-secret-key'] = current_app.config['MINIO_SECRET_KEY']
+            return request_rec
         else:
             return TransformRequest.return_all()

--- a/servicex/resources/query_transformation_request.py
+++ b/servicex/resources/query_transformation_request.py
@@ -43,7 +43,8 @@ class QueryTransformationRequest(ServiceXResource):
             request_rec = TransformRequest.to_json(
                 TransformRequest.return_request(request_id))
 
-            if current_app.config['OBJECT_STORE_ENABLED']:
+            if current_app.config['OBJECT_STORE_ENABLED'] and \
+                    request_rec['result-destination'] == TransformRequest.OBJECT_STORE_DEST:
                 request_rec['minio-endpoint'] = current_app.config['MINIO_PUBLIC_URL']
                 request_rec['minio-access-key'] = current_app.config['MINIO_ACCESS_KEY']
                 request_rec['minio-secret-key'] = current_app.config['MINIO_SECRET_KEY']

--- a/servicex/resources/submit_transformation_request.py
+++ b/servicex/resources/submit_transformation_request.py
@@ -58,7 +58,10 @@ parser.add_argument('image', required=False)
 parser.add_argument('tree-name', required=False)
 parser.add_argument('chunk-size', required=False, type=int)
 parser.add_argument('workers', required=False, type=int)
-parser.add_argument('result-destination', required=True, choices=['kafka', 'object-store'])
+parser.add_argument('result-destination', required=True, choices=[
+    TransformRequest.KAFKA_DEST,
+    TransformRequest.OBJECT_STORE_DEST
+])
 parser.add_argument('result-format', required=False,
                     choices=['arrow', 'parquet', 'root-file'], default='arrow')
 parser.add_argument('kafka', required=False, type=dict)
@@ -112,11 +115,11 @@ class SubmitTransformationRequest(ServiceXResource):
                 raise BadRequest("Must provide did or file-list but not both")
 
             if self.object_store and \
-                    transformation_request['result-destination'] == 'object-store':
+                    transformation_request['result-destination'] == TransformRequest.OBJECT_STORE_DEST:
                 self.object_store.create_bucket(request_id)
                 # WHat happens if object-store and object_store is None?
 
-            if transformation_request['result-destination'] == 'kafka':
+            if transformation_request['result-destination'] == TransformRequest.KAFKA_DEST:
                 broker = transformation_request['kafka']['broker']
             else:
                 broker = None

--- a/servicex/resources/submit_transformation_request.py
+++ b/servicex/resources/submit_transformation_request.py
@@ -115,7 +115,8 @@ class SubmitTransformationRequest(ServiceXResource):
                 raise BadRequest("Must provide did or file-list but not both")
 
             if self.object_store and \
-                    transformation_request['result-destination'] == TransformRequest.OBJECT_STORE_DEST:
+                    transformation_request['result-destination'] == \
+                    TransformRequest.OBJECT_STORE_DEST:
                 self.object_store.create_bucket(request_id)
                 # WHat happens if object-store and object_store is None?
 

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -55,7 +55,8 @@ class ResourceTestBase:
             'CODE_GEN_SERVICE_URL': 'http://localhost:5001',
             'ENABLE_AUTH': False,
             'JWT_ADMIN': 'admin',
-            'JWT_PASS': 'pass'
+            'JWT_PASS': 'pass',
+            'JWT_SECRET_KEY': 'schtum'
         }
 
     @staticmethod

--- a/tests/resources/test_query_transformation_request.py
+++ b/tests/resources/test_query_transformation_request.py
@@ -45,14 +45,19 @@ class TestQueryTransformationRequest(ResourceTestBase):
         assert response.json == [{'request_id': '123'}, {'request_id': '456'}]
         mock_transform_request_read_all.assert_called()
 
-    def test_query_single_request(self, mocker, mock_rabbit_adaptor):
+    def test_query_single_request_no_object_store(self, mocker, mock_rabbit_adaptor):
         import servicex
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
             return_value=self._generate_transform_request())
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        local_config = {
+            'OBJECT_STORE_ENABLED': False
+        }
+
+        client = self._test_client(additional_config=local_config,
+                                   rabbit_adaptor=mock_rabbit_adaptor)
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
         print(response.json)
@@ -64,6 +69,41 @@ class TestQueryTransformationRequest(ResourceTestBase):
                                  'workers': 42, 'result-destination': 'kafka',
                                  'result-format': 'arrow',
                                  'kafka-broker': 'http://ssl-hep.org.kafka:12345',
+                                 'workflow-name': None,
+                                 'generated-code-cm': None}
+
+        mock_transform_request_read.assert_called_with('1234')
+
+    def test_query_single_request_with_object_store(self, mocker, mock_rabbit_adaptor):
+        import servicex
+        mock_transform_request_read = mocker.patch.object(
+            servicex.models.TransformRequest,
+            'return_request',
+            return_value=self._generate_transform_request())
+
+        local_config = {
+            'OBJECT_STORE_ENABLED': True,
+            'MINIO_PUBLIC_URL': 'minio.servicex.com:9000',
+            'MINIO_ACCESS_KEY': 'miniouser',
+            'MINIO_SECRET_KEY': 'leftfoot1'
+        }
+
+        client = self._test_client(additional_config=local_config,
+                                   rabbit_adaptor=mock_rabbit_adaptor)
+        response = client.get('/servicex/transformation/1234')
+        assert response.status_code == 200
+        print(response.json)
+        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
+                                 'columns': 'electron.eta(), muon.pt()',
+                                 'selection': None,
+                                 'tree-name': "Events",
+                                 'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
+                                 'workers': 42, 'result-destination': 'kafka',
+                                 'result-format': 'arrow',
+                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
+                                 'minio-access-key': 'miniouser',
+                                 'minio-endpoint': 'minio.servicex.com:9000',
+                                 'minio-secret-key': 'leftfoot1',
                                  'workflow-name': None,
                                  'generated-code-cm': None}
 

--- a/tests/resources/test_query_transformation_request.py
+++ b/tests/resources/test_query_transformation_request.py
@@ -76,10 +76,12 @@ class TestQueryTransformationRequest(ResourceTestBase):
 
     def test_query_single_request_with_object_store(self, mocker, mock_rabbit_adaptor):
         import servicex
+        object_store_transform_request = self._generate_transform_request()
+        object_store_transform_request.result_destination = 'object-store'
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
-            return_value=self._generate_transform_request())
+            return_value=object_store_transform_request)
 
         local_config = {
             'OBJECT_STORE_ENABLED': True,
@@ -98,12 +100,46 @@ class TestQueryTransformationRequest(ResourceTestBase):
                                  'selection': None,
                                  'tree-name': "Events",
                                  'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
-                                 'workers': 42, 'result-destination': 'kafka',
-                                 'result-format': 'arrow',
                                  'kafka-broker': 'http://ssl-hep.org.kafka:12345',
+                                 'workers': 42, 'result-destination': 'object-store',
+                                 'result-format': 'arrow',
                                  'minio-access-key': 'miniouser',
                                  'minio-endpoint': 'minio.servicex.com:9000',
                                  'minio-secret-key': 'leftfoot1',
+                                 'workflow-name': None,
+                                 'generated-code-cm': None}
+
+        mock_transform_request_read.assert_called_with('1234')
+
+    def test_query_single_request_to_kafka(self, mocker, mock_rabbit_adaptor):
+        import servicex
+        kafka_transform_request = self._generate_transform_request()
+        kafka_transform_request.result_destination = 'kafka'
+        mock_transform_request_read = mocker.patch.object(
+            servicex.models.TransformRequest,
+            'return_request',
+            return_value=kafka_transform_request)
+
+        local_config = {
+            'OBJECT_STORE_ENABLED': True,
+            'MINIO_PUBLIC_URL': 'minio.servicex.com:9000',
+            'MINIO_ACCESS_KEY': 'miniouser',
+            'MINIO_SECRET_KEY': 'leftfoot1'
+        }
+
+        client = self._test_client(additional_config=local_config,
+                                   rabbit_adaptor=mock_rabbit_adaptor)
+        response = client.get('/servicex/transformation/1234')
+        assert response.status_code == 200
+        print(response.json)
+        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
+                                 'columns': 'electron.eta(), muon.pt()',
+                                 'selection': None,
+                                 'tree-name': "Events",
+                                 'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
+                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
+                                 'workers': 42, 'result-destination': 'kafka',
+                                 'result-format': 'arrow',
                                  'workflow-name': None,
                                  'generated-code-cm': None}
 


### PR DESCRIPTION
# Problem
A client of serviceX needs to know the URL, username, and password of the Minio instance where results are stored.

Partial solution to [ServiceX issue 146](https://github.com/ssl-hep/ServiceX/issues/146)

# Approach
Add a new config option to the app called `MINIO_PUBLIC_URL` add this, along with the values of `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` to the `/servicex/transformation/<string:request_id>` endpoint.

New response document looks like:
```
{'request_id': 'BR549', 'did': '123-456-789',
                                 'columns': 'electron.eta(), muon.pt()',
                                 'selection': None,
                                 'tree-name': "Events",
                                 'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
                                 'workers': 42, 'result-destination': 'kafka',
                                 'result-format': 'arrow',
                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
                                 'minio-access-key': 'miniouser',
                                 'minio-endpoint': 'minio.servicex.com:9000',
                                 'minio-secret-key': 'leftfoot1',
                                 'workflow-name': None,
                                 'generated-code-cm': None}
```