### PR TITLE
Add check for bad request ID in TransformationStatus

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -28,6 +28,7 @@
 import hashlib
 from sqlalchemy import func, ForeignKey
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm.exc import NoResultFound
 
 db = SQLAlchemy()
 
@@ -167,13 +168,17 @@ class TransformRequest(db.Model):
 
     @classmethod
     def return_request(cls, request_id):
-        return cls.query.filter_by(request_id=request_id).one()
+        try:
+            return cls.query.filter_by(request_id=request_id).one()
+        except NoResultFound:
+            return None
 
     @classmethod
     def files_remaining(cls, request_id):
         submitted_request = cls.return_request(request_id)
         count = TransformationResult.count(request_id)
-        if submitted_request.files:
+
+        if submitted_request and submitted_request.files:
             return submitted_request.files - int(count or 0)
         else:
             return None

--- a/servicex/resources/transform_status.py
+++ b/servicex/resources/transform_status.py
@@ -49,6 +49,10 @@ class TransformationStatus(ServiceXResource):
         if not is_auth:
             return {'message': f'Authentication Failed: {str(auth_reject_message)}'}, 401
 
+        submitted_request = TransformRequest.return_request(request_id)
+        if not submitted_request:
+            return "Transform Not Found", "404"
+
         status_request = status_request_parser.parse_args()
 
         count = TransformationResult.count(request_id)


### PR DESCRIPTION
# Problem
If you request the status of a non-existent transform job you get back an internal error and a nasty stack trace in the log
Solution for [ServiceX Issue 159](https://github.com/ssl-hep/ServiceX/issues/159)

# Approach
Do a check to make sure the transform exists