### PR TITLE
Add more fields to UserModel and registration form

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,10 @@ to secured endpoints should have an HTTP header called ``Authorization`` it must
 have as the value ``Bearer`` and the token returned by the login POST.
 
 New users may request an account via the web page hosted at ``/``. This form
-asks for the username and password they wish to use. New accounts are marked
-as pending. An admin user can view the pending accounts with a GET on the
-``/pending`` endpoint. They can approve the request with a POST to ``/accept``
-with a body of:
+asks for the username and password they wish to use, as well as some other
+basic information. New accounts are marked as pending. An admin user can view
+the pending accounts with a GET on the ``/pending`` endpoint.
+They can approve the request with a POST to ``/accept`` with a body of:
 
 .. code:: json
 
@@ -102,7 +102,7 @@ Then use your favorite postgres sql client to connect to this
 database with the connection URL``jdbc:postgresql://localhost:5432/postgres``
 with the user postgres and the password leftfoot1.
 
-Of particular insterest is the ``file_status`` table. It contains entries for
+Of particular interest is the ``file_status`` table. It contains entries for
 each transformed root file when it starts and when it finishes, retries, or
 reports an error.
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ If ``ENABLE_AUTH``  is set to True endpoints will be protected with JWT bearer
 tokens.
 
 An initial admin account is created when the app is started. That account's
-username is found in the ``JWT_ACCOUNT`` config property, and the password is
+email is found in the ``JWT_ADMIN`` config property, and the password is
 set from ``JWT_PASSWORD``. This account can be used for all interactions with
 the endpoints, and can also be used to enable new users who submit requests for
 access to the system.
@@ -30,7 +30,7 @@ endpoint. This POST request expects a JSON body that looks like:
 .. code:: json
 
     {
-        "username": "admin",
+        "email": "admin@example.com",
         "password": "password"
     }
 
@@ -40,7 +40,7 @@ to secured endpoints should have an HTTP header called ``Authorization`` it must
 have as the value ``Bearer`` and the token returned by the login POST.
 
 New users may request an account via the web page hosted at ``/``. This form
-asks for the username and password they wish to use, as well as some other
+asks for the email and password they wish to use, as well as some other
 basic information. New accounts are marked as pending. An admin user can view
 the pending accounts with a GET on the ``/pending`` endpoint.
 They can approve the request with a POST to ``/accept`` with a body of:
@@ -48,7 +48,7 @@ They can approve the request with a POST to ``/accept`` with a body of:
 .. code:: json
 
     {
-        "username": "<the username>"
+        "email": "<the email>"
     }
 
 The API can also be configured to send notifications of new user registrations

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -163,6 +163,8 @@ def create_app(test_config=None,
             if not UserModel.find_by_username(app.config['JWT_ADMIN']):
                 try:
                     new_user = UserModel(
+                        email=app.config['JWT_ADMIN_EMAIL'],
+                        full_name=app.config['JWT_ADMIN'],
                         username=app.config['JWT_ADMIN'],
                         key=UserModel.generate_hash(app.config['JWT_PASS']),
                         admin=True,

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -160,12 +160,11 @@ def create_app(test_config=None,
             from flask_jwt_extended import (create_refresh_token, create_access_token)
             db.init_app(app)
             db.create_all()
-            if not UserModel.find_by_username(app.config['JWT_ADMIN']):
+            if not UserModel.find_by_email(app.config['JWT_ADMIN']):
                 try:
                     new_user = UserModel(
-                        email=app.config['JWT_ADMIN_EMAIL'],
-                        full_name=app.config['JWT_ADMIN'],
-                        username=app.config['JWT_ADMIN'],
+                        email=app.config['JWT_ADMIN'],
+                        full_name="Administrator",
                         key=UserModel.generate_hash(app.config['JWT_PASS']),
                         admin=True,
                         pending=False

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -29,8 +29,9 @@ from datetime import datetime
 import hashlib
 
 from sqlalchemy import func, ForeignKey, DateTime
-from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm.exc import NoResultFound
+from flask_sqlalchemy import SQLAlchemy
+
 
 db = SQLAlchemy()
 

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -25,8 +25,10 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime
 import hashlib
-from sqlalchemy import func, ForeignKey
+
+from sqlalchemy import func, ForeignKey, DateTime
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -35,11 +37,17 @@ db = SQLAlchemy()
 
 class UserModel(db.Model):
     __tablename__ = 'users'
+    admin = db.Column(db.Boolean, default=False)
+    created_at = db.Column(DateTime, default=datetime.utcnow)
     id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(120), unique=True, nullable=False)
+    email = db.Column(db.String(320), nullable=False, unique=True)
+    full_name = db.Column(db.String(120), nullable=False)
+    institution = db.Column(db.String(120))
     key = db.Column(db.String(120), nullable=False)
-    admin = db.Column(db.Boolean, nullable=True)
-    pending = db.Column(db.Boolean, nullable=False)
+    pending = db.Column(db.Boolean, default=True)
+    experiment = db.Column(db.String(120))
+    updated_at = db.Column(DateTime, default=datetime.utcnow)
+    username = db.Column(db.String(120), nullable=False, unique=True)
 
     def save_to_db(self):
         db.session.add(self)

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -48,21 +48,20 @@ class UserModel(db.Model):
     pending = db.Column(db.Boolean, default=True)
     experiment = db.Column(db.String(120))
     updated_at = db.Column(DateTime, default=datetime.utcnow)
-    username = db.Column(db.String(120), nullable=False, unique=True)
 
     def save_to_db(self):
         db.session.add(self)
         db.session.commit()
 
     @classmethod
-    def find_by_username(cls, username):
-        return cls.query.filter_by(username=username).first()
+    def find_by_email(cls, email):
+        return cls.query.filter_by(email=email).first()
 
     @classmethod
     def return_all(cls):
         def to_json(x):
             return {
-                'username': x.username,
+                'email': x.email,
                 'key': x.key,
                 'admin': x.admin,
                 'pending': x.pending
@@ -74,7 +73,7 @@ class UserModel(db.Model):
     def return_all_pending(cls):
         def to_json(x):
             return {
-                'username': x.username,
+                'email': x.email,
                 'key': x.key,
                 'admin': x.admin
             }
@@ -101,10 +100,10 @@ class UserModel(db.Model):
             return {'message': 'Something went wrong'}
 
     @classmethod
-    def accept(cls, username):
-        pending_user = UserModel.find_by_username(username)
+    def accept(cls, email):
+        pending_user = UserModel.find_by_email(email)
         if not pending_user:
-            raise NoResultFound(f"No user registered with username: {username}")
+            raise NoResultFound(f"No user registered with email: {email}")
         pending_user.pending = False
         pending_user.save_to_db()
 

--- a/servicex/resources/jwt/accept_user.py
+++ b/servicex/resources/jwt/accept_user.py
@@ -9,7 +9,7 @@ from servicex.models import UserModel
 from servicex.resources.servicex_resource import ServiceXResource
 
 parser = reqparse.RequestParser()
-parser.add_argument('username', help='This field cannot be blank', required=True)
+parser.add_argument('email', help='This field cannot be blank', required=True)
 
 
 class AcceptUser(ServiceXResource):
@@ -20,9 +20,9 @@ class AcceptUser(ServiceXResource):
             return {'message': f'Authentication Failed: {str(auth_reject_message)}'}, 401
         try:
             data = parser.parse_args()
-            username = data['username']
-            UserModel.accept(username)
-            return {'message': 'user {} now ready for access'.format(username)}
+            email = data['email']
+            UserModel.accept(email)
+            return {'message': 'user {} now ready for access'.format(email)}
         except NoResultFound as err:
             return {'message': str(err)}, 404
         except Exception:

--- a/servicex/resources/jwt/slack_action.py
+++ b/servicex/resources/jwt/slack_action.py
@@ -29,8 +29,8 @@ class SlackAction(ServiceXResource):
 
             action_id = action['action_id']
             if action_id == "accept_user":
-                username = action['value']
-                UserModel.accept(username)
+                email = action['value']
+                UserModel.accept(email)
                 response = signup_ia(original_msg, initiating_user, action_id)
                 slack_response = requests.post(response_url, response)
                 slack_response.raise_for_status()

--- a/servicex/resources/jwt/slack_msg_builder.py
+++ b/servicex/resources/jwt/slack_msg_builder.py
@@ -1,12 +1,12 @@
 import json
 
 
-def signup(username) -> str:
+def signup(email) -> str:
     text_block = {
         "type": "section",
         "text": {
             "type": "mrkdwn",
-            "text": f"New signup from {username}"
+            "text": f"New signup from {email}"
         }
     }
     approve_btn = {
@@ -17,7 +17,7 @@ def signup(username) -> str:
         },
         "style": "primary",
         "action_id": "accept_user",
-        "value": f"{username}"
+        "value": f"{email}"
     }
     reject_btn = {
         "type": "button",
@@ -27,7 +27,7 @@ def signup(username) -> str:
         },
         "style": "danger",
         "action_id": "reject_user",
-        "value": f"{username}"
+        "value": f"{email}"
     }
     actions_block = {
         "type": "actions",
@@ -35,7 +35,7 @@ def signup(username) -> str:
     }
     return json.dumps({
         "blocks": [text_block, actions_block],
-        "text": f"New signup from {username}."
+        "text": f"New signup from {email}."
     })
 
 

--- a/servicex/resources/jwt/user_login.py
+++ b/servicex/resources/jwt/user_login.py
@@ -31,30 +31,30 @@ from flask_jwt_extended import (create_access_token, create_refresh_token)
 
 
 parser = reqparse.RequestParser()
-parser.add_argument('username', help='This field cannot be blank', required=True)
+parser.add_argument('email', help='This field cannot be blank', required=True)
 parser.add_argument('password', help='This field cannot be blank', required=True)
 
 
 class UserLogin(Resource):
     def post(self):
         data = parser.parse_args()
-        current_user = UserModel.find_by_username(data['username'])
+        current_user = UserModel.find_by_email(data['email'])
 
         if not current_user:
-            return {'message': "User {} doesn't exist".format(data['username'])}, 404
+            return {'message': "User {} doesn't exist".format(data['email'])}, 404
 
         if current_user.pending:
             return {
                     'message':
                     "User {} is still pending. Contact administrator to approve request".
-                    format(data['username'])
+                    format(data['email'])
                    }, 401
 
         if UserModel.verify_hash(data['password'], current_user.key):
-            access_token = create_access_token(identity=data['username'])
-            refresh_token = create_refresh_token(identity=data['username'])
+            access_token = create_access_token(identity=data['email'])
+            refresh_token = create_refresh_token(identity=data['email'])
             return {
-                'message': 'Logged in as {}'.format(current_user.username),
+                'message': 'Logged in as {}'.format(current_user.email),
                 'access_token': access_token,
                 'refresh_token': refresh_token
                 }

--- a/servicex/resources/jwt/user_registration.py
+++ b/servicex/resources/jwt/user_registration.py
@@ -40,7 +40,6 @@ parser.add_argument('full_name', help='This field cannot be blank', required=Tru
 parser.add_argument('email', help='This field cannot be blank', required=True)
 parser.add_argument('institution')
 parser.add_argument('experiment')
-parser.add_argument('username', help='This field cannot be blank', required=True)
 parser.add_argument('password', help='This field cannot be blank', required=True)
 parser.add_argument('confirm_password', help='This field cannot be blank', required=True)
 
@@ -50,8 +49,8 @@ class UserRegistration(Resource):
     def post(self):
         data = parser.parse_args()
 
-        if UserModel.find_by_username(data['username']):
-            return {'message': 'User {} already exists'.format(data['username'])}
+        if UserModel.find_by_email(data['email']):
+            return {'message': 'User {} already exists'.format(data['email'])}
 
         if data.password != data.confirm_password:
             return {'message': 'Passwords do not match'}
@@ -63,18 +62,17 @@ class UserRegistration(Resource):
             institution=data.institution,
             key=data.key,
             experiment=data.experiment,
-            username=data.username
         )
 
         try:
             new_user.save_to_db()
             webhook_url = current_app.config.get("SIGNUP_WEBHOOK_URL")
             if webhook_url:
-                res = requests.post(webhook_url, signup(new_user.username))
+                res = requests.post(webhook_url, signup(new_user.email))
                 # Raise exception on error (e.g. bad request or forbidden url)
                 res.raise_for_status()
             return {
-                'message': 'User {} added to pending user list'.format(data['username']),
+                'message': 'User {} added to pending user list'.format(data['email']),
             }
         except Exception:
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -59,7 +59,7 @@ class ServiceXResource(Resource):
             if not user_id:
                 return False, "No auth provided"
 
-            user_record = UserModel.find_by_username(user_id)
+            user_record = UserModel.find_by_email(user_id)
 
             if user_record and not user_record.pending:
                 return True, None
@@ -105,7 +105,7 @@ class ServiceXResource(Resource):
             return True, None
         try:
             user_id = flask_jwt_extended.get_jwt_identity()
-            user_record = UserModel.find_by_username(user_id)
+            user_record = UserModel.find_by_email(user_id)
 
             if user_record and user_record.admin:
                 return True, None

--- a/servicex/templates/index.html
+++ b/servicex/templates/index.html
@@ -24,8 +24,6 @@
           <option value="ATLAS">ATLAS</option>
           <option value="CMS">CMS</option>
         </select><br>
-        <label for="username">Username:</label><br>
-        <input type="text" id="username" name="username"><br>
         <label for="password">Password:</label><br>
         <input type="password" id="password" name="password"><br>
         <label for="confirmation">Confirm Password:</label><br>

--- a/servicex/templates/index.html
+++ b/servicex/templates/index.html
@@ -13,10 +13,23 @@
       <h3>ServiceX</h3>
       <form action="registration" method="POST">
         <h3> register </h3>
+        <label for="full_name">Full Name:</label><br>
+        <input type="text" id="full_name" name="full_name"><br>
+        <label for="email">Email:</label><br>
+        <input type="email" id="email" name="email"><br>
+        <label for="institution">Institution:</label><br>
+        <input type="text" id="institution" name="institution"><br>
+        <label for="experiment">Experiment:</label><br>
+        <select type="text" id="experiment" name="experiment">
+          <option value="ATLAS">ATLAS</option>
+          <option value="CMS">CMS</option>
+        </select><br>
         <label for="username">Username:</label><br>
         <input type="text" id="username" name="username"><br>
         <label for="password">Password:</label><br>
-        <input type="password" id="password" name="password">
+        <input type="password" id="password" name="password"><br>
+        <label for="confirmation">Confirm Password:</label><br>
+        <input type="password" id="confirmation" name="confirm_password"><br>
         <input type="submit" value="Submit">
       </form>
     </div>


### PR DESCRIPTION
Closes ssl-hep/ServiceX#160.

This PR adds the following new fields to the UserModel and registration form:

- `full_name`
- `email` (must be unique)
- `institution`
- `project`
- `confirm_password` (registration form only, checked before saving new user)

It also adds the following new fields to the UserModel with default values upon registration:

- `email_confirmed` (False - in case we decide to confirm emails before switching to external auth)
- `created_at` (current time in UTC)
- `updated_at` (current time in UTC - in case we ever enable profile editing)

It also raises a question: If `username` and `email` are both unique, do we need to ask users for both? In theory, they could login with either one. My instinct is that emails are slightly better since they are strictly more functional. However, there are a couple downsides: it's risky to use them without confirmation and they are slightly more sensitive.