### PR TITLE
Error Reporting Endpoint

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -312,3 +312,10 @@ class FileStatus(db.Model):
     def save_to_db(self):
         db.session.add(self)
         db.session.flush()
+
+    @classmethod
+    def failures_for_request(cls, request_id):
+        return db.session.query(DatasetFile, FileStatus).filter(
+            FileStatus.request_id == request_id,
+            DatasetFile.request_id == FileStatus.request_id,
+            FileStatus.status == 'failure').all()

--- a/servicex/resources/transform_errors.py
+++ b/servicex/resources/transform_errors.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from flask_jwt_extended import jwt_optional
+
+from servicex.models import TransformRequest, FileStatus
+from servicex.resources.servicex_resource import ServiceXResource
+
+
+class TransformErrors(ServiceXResource):
+    @jwt_optional
+    def get(self, request_id):
+        is_auth, auth_reject_message = self._validate_user()
+        if not is_auth:
+            return {'message': f'Authentication Failed: {str(auth_reject_message)}'}, 401
+
+        submitted_request = TransformRequest.return_request(request_id)
+        if not submitted_request:
+            return "Transform Not Found", "404"
+
+        results = [{
+            "pod-name": result[1].pod_name,
+            "file": result[0].file_path,
+            "events": result[0].file_events,
+            "info": result[1].info
+        } for result in FileStatus.failures_for_request(request_id)]
+        return {"errors": list(results)}

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -40,6 +40,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.resources.preflight_check import PreflightCheck
     from servicex.resources.fileset_complete import FilesetComplete
     from servicex.resources.transformer_file_complete import TransformerFileComplete
+    from servicex.resources.transform_errors import TransformErrors
     from servicex.resources.jwt.all_users import AllUsers
     from servicex.resources.jwt.token_refresh import TokenRefresh
     from servicex.resources.jwt.user_login import UserLogin
@@ -73,6 +74,9 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
 
     api.add_resource(TransformationStatus,
                      '/servicex/transformation/<string:request_id>/status')
+
+    api.add_resource(TransformErrors,
+                     '/servicex/transformation/<string:request_id>/errors')
 
     # Internal service endpoints
     api.add_resource(TransformationStatusInternal,

--- a/tests/resources/test_transform_errors.py
+++ b/tests/resources/test_transform_errors.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from tests.resource_test_base import ResourceTestBase
+from servicex.models import DatasetFile, FileStatus
+
+
+class TestTransformErrors(ResourceTestBase):
+    def test_get_errors(self, mocker, mock_rabbit_adaptor):
+        import servicex
+
+        mock_transform_request_read = mocker.patch.object(
+            servicex.models.TransformRequest,
+            'return_request',
+            return_value=self._generate_transform_request())
+
+        file_error_result = [
+            (DatasetFile(
+                file_path="/foo.bar/baz.root",
+                file_events=42
+            ), FileStatus(
+                pod_name='openthepodhal',
+                info="sorry I can't"
+            ))
+        ]
+        mock_transform_errors = mocker.patch.object(
+            servicex.models.FileStatus,
+            'failures_for_request',
+            return_value=file_error_result)
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+
+        response = client.get('/servicex/transformation/1234/errors')
+        assert response.status_code == 200
+        assert response.json == {'errors': [
+            {'pod-name': 'openthepodhal',
+             'file': '/foo.bar/baz.root',
+             'events': 42,
+             'info': "sorry I can't"
+             }
+        ]}
+
+        mock_transform_request_read.assert_called_with("1234")
+        mock_transform_errors.assert_called_with("1234")
+
+    def test_get_errors_bad_request(self, mocker, mock_rabbit_adaptor):
+        import servicex
+
+        mock_transform_request_read = mocker.patch.object(
+            servicex.models.TransformRequest,
+            'return_request',
+            return_value=None)
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+
+        response = client.get('/servicex/transformation/1234/errors')
+        assert response.status_code == 404
+
+        mock_transform_request_read.assert_called_with("1234")


### PR DESCRIPTION
# Problem
If a transform fails, it's impossible for users to get back any information without access to the pod log files or Postgres database.

This is solution to [ServiceX issue 155](https://github.com/ssl-hep/ServiceX/issues/155)

# Approach
Add a new endpoint for `/servicex/transformation/<string:request_id>/errors` - this will return a JSON document containing a list of errors for each file.

Example:
```
{
    "errors": [
        {
            "pod-name": "transformer-a991f2a7-47d5-4233-9d74-437ffc5319e0-77dcb5654xxj8n",
            "file": "root://se.reef.man.poznan.pl:1094//dpm/reef.man.poznan.pl/home/atlas/atlasdatadisk/rucio/mc16_13TeV/a5/22/DAOD_EXOT15.17564946._000002.pool.root.1",
            "events": 0,
            "info": " error: Failed to transform input file root://se.reef.man.poznan.pl:1094//dpm/reef.man.poznan.pl/home/atlas/atlasdatadisk/rucio/mc16_13TeV/a5/22/DAOD_EXOT15.17564946._000002.pool.root.1: Output file /home/atlas/root:::se.reef.man.poznan.pl:1094::dpm:reef.man.poznan.pl:home:atlas:atlasdatadisk:rucio:mc16_13TeV:a5:22:DAOD_EXOT15.17564946._000002.pool.root.1 was not found -- errors: \nConfigured GCC from: /opt/lcg/gcc/8.3.0-cebb0/x86_64-centos7/bin/gcc\nConfigured AnalysisBase from: /usr/AnalysisBase/21.2.102/InstallArea/x86_64-centos7-gcc8-opt\nConfigured GCC from: /opt/lcg/gcc/8.3.0-cebb0/x86_64-centos7/bin/gcc\nConfigured AnalysisBase from: /usr/AnalysisBase/21.2.102/InstallArea/x86_64-centos7-gcc8-opt\nxAOD::Init                INFO    Environment initialised for data access\nSampleHandler with 1 files\nSample:name=ANALYSIS,tags=()\nroot://se.reef.man.poznan.pl:1094//dpm/reef.man.poznan.pl/home/atlas/atlasdatadisk/rucio/mc16_13TeV/a5/22/DAOD_EXOT15.17564946._000002.pool.root.1\n\n\nPackage.EventLoop        INFO    created subm"
        },
        {
            "pod-name": "transformer-a991f2a7-47d5-4233-9d74-437ffc5319e0-77dcb5654z49kb",
            "file": "root://se.reef.man.poznan.pl:1094//dpm/reef.man.poznan.pl/home/atlas/atlasdatadisk/rucio/mc16_13TeV/a5/22/DAOD_EXOT15.17564946._000002.pool.root.1",
            "events": 0,
            "info": " error: Failed to transform input file root://se.reef.man.poznan.pl:1094//dpm/reef.man.poznan.pl/home/atlas/atlasdatadisk/rucio/mc16_13TeV/55/3d/DAOD_EXOT15.17564946._000004.pool.root.1: Output file /home/atlas/root:::se.reef.man.poznan.pl:1094::dpm:reef.man.poznan.pl:home:atlas:atlasdatadisk:rucio:mc16_13TeV:55:3d:DAOD_EXOT15.17564946._000004.pool.root.1 was not found -- errors: \nConfigured GCC from: /opt/lcg/gcc/8.3.0-cebb0/x86_64-centos7/bin/gcc\nConfigured AnalysisBase from: /usr/AnalysisBase/21.2.102/InstallArea/x86_64-centos7-gcc8-opt\nConfigured GCC from: /opt/lcg/gcc/8.3.0-cebb0/x86_64-centos7/bin/gcc\nConfigured AnalysisBase from: /usr/AnalysisBase/21.2.102/InstallArea/x86_64-centos7-gcc8-opt\nxAOD::Init                INFO    Environment initialised for data access\nSampleHandler with 1 files\nSample:name=ANALYSIS,tags=()\nroot://se.reef.man.poznan.pl:1094//dpm/reef.man.poznan.pl/home/atlas/atlasdatadisk/rucio/mc16_13TeV/55/3d/DAOD_EXOT15.17564946._000004.pool.root.1\n\n\nPackage.EventLoop        INFO    created subm"
        },
```