### PR TITLE
Check That Docker Image Exists

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -43,6 +43,11 @@ TRANSFORMER_AUTOSCALE_ENABLED = True
 
 TRANSFORMER_MANAGER_MODE = 'external-kubernetes'
 
+# Should we validate the docker image exists on DockerHub?
+# Set to False if you are doing local development and don't want to
+# push your image
+TRANSFORMER_VALIDATE_DOCKER_IMAGE = True
+
 TRANSFORMER_MESSAGING = 'none'
 OBJECT_STORE_ENABLED = False
 MINIO_URL = 'localhost:9000'

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -35,6 +35,7 @@ import traceback
 import pika
 from flask import Flask
 
+from servicex.docker_repo_adapter import DockerRepoAdapter
 from servicex.resources.user_web import index
 from servicex.code_gen_adapter import CodeGenAdapter
 from servicex.elasticsearch_adaptor import ElasticSearchAdapter
@@ -82,7 +83,8 @@ def create_app(test_config=None,
                provided_object_store=None,
                provided_elasticsearch_adapter=None,
                provided_code_gen_service=None,
-               provided_lookup_result_processor=None):
+               provided_lookup_result_processor=None,
+               provided_docker_repo_adapter=None):
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
 
@@ -146,6 +148,11 @@ def create_app(test_config=None,
         else:
             lookup_result_processor = provided_lookup_result_processor
 
+        if not provided_docker_repo_adapter:
+            docker_repo_adapter = DockerRepoAdapter()
+        else:
+            docker_repo_adapter = provided_docker_repo_adapter
+
         api = Api(app)
 
         # ensure the instance folder exists
@@ -178,7 +185,8 @@ def create_app(test_config=None,
                     print(exc_value)
 
         add_routes(api, transformer_manager, rabbit_adaptor, object_store,
-                   elasticsearch_adaptor, code_gen_service, lookup_result_processor)
+                   elasticsearch_adaptor, code_gen_service, lookup_result_processor,
+                   docker_repo_adapter)
 
         app.add_url_rule("/", "index", index)
 

--- a/servicex/docker_repo_adapter.py
+++ b/servicex/docker_repo_adapter.py
@@ -35,7 +35,12 @@ class DockerRepoAdapter:
         self.registry_endpoint = registry_endpoint
 
     def check_image_exists(self, tagged_image):
-        (repo, image, tag) = re.search("(.+)/(.+):(.+)", tagged_image).groups()
+        search_result = re.search("(.+)/(.+):(.+)", tagged_image)
+        if not search_result or len(search_result.groups()) != 3:
+            return False
+
+        (repo, image, tag) = search_result.groups()
+
         query = f'{self.registry_endpoint}/v2/repositories/{repo}/{image}/tags/{tag}'
         r = requests.get(query)
         if r.status_code == 404:

--- a/servicex/docker_repo_adapter.py
+++ b/servicex/docker_repo_adapter.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import re
+
+import requests
+
+
+class DockerRepoAdapter:
+    def __init__(self, registry_endpoint="https://hub.docker.com"):
+        self.registry_endpoint = registry_endpoint
+
+    def check_image_exists(self, tagged_image):
+        (repo, image, tag) = re.search("(.+)/(.+):(.+)", tagged_image).groups()
+        query = f'{self.registry_endpoint}/v2/repositories/{repo}/{image}/tags/{tag}'
+        r = requests.get(query)
+        if r.status_code == 404:
+            return False
+
+        print("Requested Image: "+tagged_image+" exists, last updated "+r.json()['last_updated'])
+        return True

--- a/servicex/resources/submit_transformation_request.py
+++ b/servicex/resources/submit_transformation_request.py
@@ -126,9 +126,10 @@ class SubmitTransformationRequest(ServiceXResource):
             else:
                 broker = None
 
-            tagged_image = transformation_request['image']
-            if not self.docker_repo_adapter.check_image_exists(tagged_image):
-                return {'message': f"The requested transformer docker image doesn't exist: {tagged_image}"}, 400  # noqa: E501
+            if current_app.config['TRANSFORMER_VALIDATE_DOCKER_IMAGE']:
+                tagged_image = transformation_request['image']
+                if not self.docker_repo_adapter.check_image_exists(tagged_image):
+                    return {'message': f"The requested transformer docker image doesn't exist: {tagged_image}"}, 400  # noqa: E501
 
             request_rec = TransformRequest(
                 did=requested_did if requested_did else "File List Provided in Request",

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -29,7 +29,7 @@
 
 def add_routes(api, transformer_manager, rabbit_mq_adaptor,
                object_store, elasticsearch_adapter, code_gen_service,
-               lookup_result_processor):
+               lookup_result_processor, docker_repo_adapter):
     from servicex.resources.submit_transformation_request import SubmitTransformationRequest
     from servicex.resources.transform_start import TransformStart
     from servicex.resources.transform_status \
@@ -56,7 +56,8 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
                                          object_store=object_store,
                                          elasticsearch_adapter=elasticsearch_adapter,
                                          code_gen_service=code_gen_service,
-                                         lookup_result_processor=lookup_result_processor)
+                                         lookup_result_processor=lookup_result_processor,
+                                         docker_repo_adapter=docker_repo_adapter)
 
     # User management and Authentication Endpoints
     api.add_resource(UserRegistration, '/registration')

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -31,6 +31,7 @@ from servicex import create_app
 from servicex.models import TransformRequest
 from servicex.rabbit_adaptor import RabbitAdaptor
 from servicex.code_gen_adapter import CodeGenAdapter
+from servicex.docker_repo_adapter import DockerRepoAdapter
 
 
 class ResourceTestBase:
@@ -66,7 +67,8 @@ class ResourceTestBase:
                      object_store=None,
                      elasticsearch_adapter=None,
                      code_gen_service=None,
-                     lookup_result_processor=None):
+                     lookup_result_processor=None,
+                     docker_repo_adapter=None):
         config = ResourceTestBase._app_config()
         config['TRANSFORMER_MANAGER_ENABLED'] = False
         config['TRANSFORMER_MANAGER_MODE'] = 'external'
@@ -76,7 +78,7 @@ class ResourceTestBase:
 
         app = create_app(config, transformation_manager, rabbit_adaptor,
                          object_store, elasticsearch_adapter, code_gen_service,
-                         lookup_result_processor)
+                         lookup_result_processor, docker_repo_adapter)
 
         return app.test_client()
 
@@ -105,3 +107,9 @@ class ResourceTestBase:
     @fixture
     def mock_code_gen_service(self, mocker):
         return mocker.MagicMock(CodeGenAdapter)
+
+    @fixture
+    def mock_docker_repo_adapter(self, mocker):
+        docker = mocker.MagicMock(DockerRepoAdapter)
+        docker.check_image_exists = mocker.Mock(return_value=True)
+        return docker

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -49,6 +49,7 @@ class ResourceTestBase:
             'TRANSFORMER_AUTOSCALE_ENABLED': True,
             'ADVERTISED_HOSTNAME': 'cern.analysis.ch:5000',
             'TRANSFORMER_PULL_POLICY': 'Always',
+            'TRANSFORMER_VALIDATE_DOCKER_IMAGE': True,
             'OBJECT_STORE_ENABLED': False,
             'MINIO_URL': 'localhost:9000',
             'MINIO_ACCESS_KEY': 'miniouser',

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -257,6 +257,22 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         assert response.status_code == 400
         assert response.json == {"message": "The requested transformer docker image doesn't exist: ssl-hep/foo:latest"}  # noqa: E501
 
+    def test_submit_transformation_request_no_docker_check(self, mocker,
+                                                           mock_rabbit_adaptor,
+                                                           mock_docker_repo_adapter):
+
+        mock_docker_repo_adapter.check_image_exists = mocker.Mock(return_value=False)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter,
+                                   additional_config={
+                                       'TRANSFORMER_VALIDATE_DOCKER_IMAGE': False}
+                                   )
+
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+        assert response.status_code == 200
+        mock_docker_repo_adapter.check_image_exists.assert_not_called()
+
     def test_submit_transformation_with_root_file_selection_error(self, mocker,
                                                                   mock_rabbit_adaptor,
                                                                   mock_code_gen_service):

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -84,8 +84,10 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         response = client.post('/servicex/transformation', json=request)
         assert response.status_code == 400
 
-    def test_submit_transformation_bad_workflow(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_submit_transformation_bad_workflow(self, mock_rabbit_adaptor,
+                                                mock_docker_repo_adapter):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
         request = self._generate_transformation_request()
         request['columns'] = None
         request['selection'] = None
@@ -93,17 +95,21 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         r = client.post('/servicex/transformation', json=request)
         assert r.status_code == 400
 
-    def test_submit_transformation_request_throws_exception(self, mocker, mock_rabbit_adaptor):
+    def test_submit_transformation_request_throws_exception(self, mocker,
+                                                            mock_rabbit_adaptor,
+                                                            mock_docker_repo_adapter):
         mock_rabbit_adaptor.setup_queue = mocker.Mock(side_effect=Exception('Test'))
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
 
         response = client.post('/servicex/transformation',
                                json=self._generate_transformation_request())
         assert response.status_code == 500
         assert response.json == {"message": "Something went wrong"}
 
-    def test_submit_transformation(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_submit_transformation(self, mock_rabbit_adaptor, mock_docker_repo_adapter):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
         response = client.post('/servicex/transformation',
                                json=self._generate_transformation_request())
 
@@ -150,12 +156,14 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
     def test_submit_transformation_with_root_file(self, mocker,
                                                   mock_rabbit_adaptor,
-                                                  mock_code_gen_service):
+                                                  mock_code_gen_service,
+                                                  mock_docker_repo_adapter):
         mock_code_gen_service.generate_code_for_selection = mocker.Mock(return_value='my-cm')
         request = self._generate_transformation_request_xAOD_root_file()
 
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   code_gen_service=mock_code_gen_service)
+                                   code_gen_service=mock_code_gen_service,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
         response = client.post('/servicex/transformation',
                                json=request)
 
@@ -204,7 +212,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
     def test_submit_transformation_file_list(self, mocker,
                                              mock_rabbit_adaptor,
-                                             mock_code_gen_service):
+                                             mock_code_gen_service,
+                                             mock_docker_repo_adapter):
         request = self._generate_transformation_request()
         request['did'] = None
         request['file-list'] = ["file1", "file2"]
@@ -213,7 +222,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
                                    code_gen_service=mock_code_gen_service,
-                                   lookup_result_processor=mock_processor)
+                                   lookup_result_processor=mock_processor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
 
         response = client.post('/servicex/transformation',
                                json=request)
@@ -233,6 +243,19 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         mock_processor.report_fileset_complete.assert_called()
         fileset_complete_call = mock_processor.report_fileset_complete.call_args
         assert fileset_complete_call[1]['num_files'] == 2
+
+    def test_submit_transformation_request_bad_image(self, mocker,
+                                                     mock_rabbit_adaptor,
+                                                     mock_docker_repo_adapter):
+
+        mock_docker_repo_adapter.check_image_exists = mocker.Mock(return_value=False)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+        assert response.status_code == 400
+        assert response.json == {"message": "The requested transformer docker image doesn't exist: ssl-hep/foo:latest"}  # noqa: E501
 
     def test_submit_transformation_with_root_file_selection_error(self, mocker,
                                                                   mock_rabbit_adaptor,
@@ -280,7 +303,9 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
         assert response.status_code == 400
 
-    def test_submit_transformation_with_object_store(self, mocker, mock_rabbit_adaptor):
+    def test_submit_transformation_with_object_store(self, mocker,
+                                                     mock_rabbit_adaptor,
+                                                     mock_docker_repo_adapter):
         from servicex import ObjectStoreManager
 
         local_config = {
@@ -301,7 +326,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         mock_object_store = mocker.MagicMock(ObjectStoreManager)
         client = self._test_client(additional_config=local_config,
                                    rabbit_adaptor=mock_rabbit_adaptor,
-                                   object_store=mock_object_store)
+                                   object_store=mock_object_store,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
         response = client.post('/servicex/transformation',
                                json=transformation_request)
         assert response.status_code == 200
@@ -315,7 +341,9 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             assert saved_obj.result_destination == 'object-store'
             assert saved_obj.result_format == 'parquet'
 
-    def test_submit_transformation_with_elasticsearch(self, mocker, mock_rabbit_adaptor):
+    def test_submit_transformation_with_elasticsearch(self, mocker,
+                                                      mock_rabbit_adaptor,
+                                                      mock_docker_repo_adapter):
 
         transformation_request = {'did': '123-45-678',
                                   'columns': 'electron.eta(), muon.pt()',
@@ -328,7 +356,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         mock_elasticsearch_adapter = mocker.MagicMock(ElasticSearchAdapter)
 
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   elasticsearch_adapter=mock_elasticsearch_adapter)
+                                   elasticsearch_adapter=mock_elasticsearch_adapter,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
 
         response = client.post('/servicex/transformation',
                                json=transformation_request)
@@ -351,7 +380,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         assert record_body['status'] == 'locating DID'
         assert record_body['info'] == ' '
 
-    def test_submit_with_auth(self, mocker, mock_rabbit_adaptor):
+    def test_submit_with_auth(self, mocker, mock_rabbit_adaptor, mock_docker_repo_adapter):
         import servicex.resources.submit_transformation_request
 
         local_config = {
@@ -372,7 +401,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             return_value=(True, None))
 
         client = self._test_client(additional_config=local_config,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
 
         response = client.post('/servicex/transformation',
                                json=transformation_request)

--- a/tests/test_docker_repo_adapter.py
+++ b/tests/test_docker_repo_adapter.py
@@ -52,3 +52,16 @@ class TestDockerRepoAdapter:
         docker = DockerRepoAdapter()
         result = docker.check_image_exists("foo/bar:baz")
         assert not result
+
+    def test_check_image_exists_invalid_name(self, mocker):
+        import requests
+        mock_response = mocker.Mock()
+        mocker.patch.object(requests, "get", return_value=mock_response)
+        mock_response.status_code = 404
+        docker = DockerRepoAdapter()
+        result = docker.check_image_exists("foobar:baz")
+        assert not result
+
+        assert not docker.check_image_exists("foo/barbaz")
+        assert not docker.check_image_exists("foobarbaz")
+        assert not docker.check_image_exists("")

--- a/tests/test_docker_repo_adapter.py
+++ b/tests/test_docker_repo_adapter.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2020, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from servicex.docker_repo_adapter import DockerRepoAdapter
+
+
+class TestDockerRepoAdapter:
+    def test_check_image_exists(self, mocker):
+        import requests
+        mock_response = mocker.Mock()
+        mock_get = mocker.patch.object(requests, "get", return_value=mock_response)
+        mock_response.status_code = 200
+        mock_response.json = mocker.Mock(return_value={
+            'last_updated': '2020-07-22T21:13:55.317762Z'})
+        docker = DockerRepoAdapter()
+        result = docker.check_image_exists("foo/bar:baz")
+        assert result
+
+        mock_get.assert_called_with(
+            'https://hub.docker.com/v2/repositories/foo/bar/tags/baz'
+        )
+
+    def test_check_image_exists_not_there(self, mocker):
+        import requests
+        mock_response = mocker.Mock()
+        mocker.patch.object(requests, "get", return_value=mock_response)
+        mock_response.status_code = 404
+        docker = DockerRepoAdapter()
+        result = docker.check_image_exists("foo/bar:baz")
+        assert not result


### PR DESCRIPTION
# Problem
If a user submits a transform request with a docker image that doesn't exist, the transformers die a long slow death. 
Solution to [ServiceX issue 154](https://github.com/ssl-hep/ServiceX/issues/154)

# Approach
Use the [Docker repository API](https://docs.docker.com/registry/spec/api/) to see if the requested image exists.
Created a new class called `DockerRepoAdapter` which holds the code for interacting with DockerHub.
Added a check to the `SubmitTransformationRequest` handler.

# How to Test
1. Create a transform request with an invalid docker image
2. You should get back a 400 error
3. Submit a transform request with a valid docker image
4. Transformers launch
