### PR TITLE
Autoscale configuration

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -41,6 +41,12 @@ TRANSFORMER_MANAGER_ENABLED = True
 # start the requested number of transformers
 TRANSFORMER_AUTOSCALE_ENABLED = True
 
+# Use one core per transformer
+TRANSFORMER_CPU_LIMIT = 1
+
+# CPU threshold for HPA (in percent) to spawn additional transformers
+TRANSFORMER_CPU_SCALE_THRESHOLD = 70
+
 TRANSFORMER_MANAGER_MODE = 'external-kubernetes'
 
 TRANSFORMER_MESSAGING = 'none'

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -171,7 +171,9 @@ class TransformerManager:
             spec=client.V1HorizontalPodAutoscalerSpec(
                 max_replicas=workers,
                 scale_target_ref=target,
-                target_cpu_utilization_percentage=current_app.config['TRANSFORMER_CPU_SCALE_THRESHOLD']
+                target_cpu_utilization_percentage=current_app.config[
+                    'TRANSFORMER_CPU_SCALE_THRESHOLD'
+                    ]
             )
         )
 

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -171,7 +171,7 @@ class TransformerManager:
             spec=client.V1HorizontalPodAutoscalerSpec(
                 max_replicas=workers,
                 scale_target_ref=target,
-                target_cpu_utilization_percentage=current_app.config['TRANSFORMER_CPU_LIMIT']
+                target_cpu_utilization_percentage=current_app.config['TRANSFORMER_CPU_SCALE_THRESHOLD']
             )
         )
 

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -111,7 +111,7 @@ class TransformerManager:
             python_args[0] += " --brokerlist "+kafka_broker
 
         resources = client.V1ResourceRequirements(
-            limits={"cpu": 1}
+            limits={"cpu": current_app.config['TRANSFORMER_CPU_LIMIT']}
         )
         # Configure Pod template container
         container = client.V1Container(
@@ -171,7 +171,7 @@ class TransformerManager:
             spec=client.V1HorizontalPodAutoscalerSpec(
                 max_replicas=workers,
                 scale_target_ref=target,
-                target_cpu_utilization_percentage=1
+                target_cpu_utilization_percentage=current_app.config['TRANSFORMER_CPU_LIMIT']
             )
         )
 

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -80,7 +80,8 @@ class TestTransformerManager(ResourceTestBase):
 
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   additional_config={'TRANSFORMER_CPU_LIMIT': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -118,7 +119,8 @@ class TestTransformerManager(ResourceTestBase):
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
                                    rabbit_adaptor=mock_rabbit_adaptor,
-                                   additional_config={'TRANSFORMER_AUTOSCALE_ENABLED': False})
+                                   additional_config={'TRANSFORMER_AUTOSCALE_ENABLED': False,
+                                                      'TRANSFORMER_CPU_LIMIT': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -140,7 +142,8 @@ class TestTransformerManager(ResourceTestBase):
         mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
 
         additional_config = {
-            'TRANSFORMER_LOCAL_PATH': '/tmp/foo'
+            'TRANSFORMER_LOCAL_PATH': '/tmp/foo',
+            'TRANSFORMER_CPU_LIMIT': 30
         }
 
         transformer = TransformerManager('external-kubernetes')
@@ -174,7 +177,8 @@ class TestTransformerManager(ResourceTestBase):
 
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   additional_config={'TRANSFORMER_CPU_LIMIT': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -206,7 +210,8 @@ class TestTransformerManager(ResourceTestBase):
             'OBJECT_STORE_ENABLED': True,
             'MINIO_URL_TRANSFORMER': 'rolling-snail-minio:9000',
             'MINIO_ACCESS_KEY': 'itsame',
-            'MINIO_SECRET_KEY': 'shhh'
+            'MINIO_SECRET_KEY': 'shhh',
+            'TRANSFORMER_CPU_LIMIT': 30
         }
 
         client = self._test_client(additional_config=my_config,
@@ -243,7 +248,8 @@ class TestTransformerManager(ResourceTestBase):
         transformer = TransformerManager('external-kubernetes')
 
         client = self._test_client(transformation_manager=transformer,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   additional_config={'TRANSFORMER_CPU_LIMIT': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -81,7 +81,8 @@ class TestTransformerManager(ResourceTestBase):
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
                                    rabbit_adaptor=mock_rabbit_adaptor,
-                                   additional_config={'TRANSFORMER_CPU_LIMIT': 30})
+                                   additional_config={'TRANSFORMER_CPU_LIMIT': 1,
+                                                      'TRANSFORMER_CPU_SCALE_THRESHOLD': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -120,7 +121,8 @@ class TestTransformerManager(ResourceTestBase):
         client = self._test_client(transformation_manager=transformer,
                                    rabbit_adaptor=mock_rabbit_adaptor,
                                    additional_config={'TRANSFORMER_AUTOSCALE_ENABLED': False,
-                                                      'TRANSFORMER_CPU_LIMIT': 30})
+                                                      'TRANSFORMER_CPU_LIMIT': 1,
+                                                      'TRANSFORMER_CPU_SCALE_THRESHOLD': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -143,7 +145,8 @@ class TestTransformerManager(ResourceTestBase):
 
         additional_config = {
             'TRANSFORMER_LOCAL_PATH': '/tmp/foo',
-            'TRANSFORMER_CPU_LIMIT': 30
+            'TRANSFORMER_CPU_LIMIT': 1,
+            'TRANSFORMER_CPU_SCALE_THRESHOLD': 30
         }
 
         transformer = TransformerManager('external-kubernetes')
@@ -178,7 +181,8 @@ class TestTransformerManager(ResourceTestBase):
         transformer = TransformerManager('external-kubernetes')
         client = self._test_client(transformation_manager=transformer,
                                    rabbit_adaptor=mock_rabbit_adaptor,
-                                   additional_config={'TRANSFORMER_CPU_LIMIT': 30})
+                                   additional_config={'TRANSFORMER_CPU_LIMIT': 1,
+                                                      'TRANSFORMER_CPU_SCALE_THRESHOLD': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -211,7 +215,8 @@ class TestTransformerManager(ResourceTestBase):
             'MINIO_URL_TRANSFORMER': 'rolling-snail-minio:9000',
             'MINIO_ACCESS_KEY': 'itsame',
             'MINIO_SECRET_KEY': 'shhh',
-            'TRANSFORMER_CPU_LIMIT': 30
+            'TRANSFORMER_CPU_LIMIT': 1,
+            'TRANSFORMER_CPU_SCALE_THRESHOLD': 30
         }
 
         client = self._test_client(additional_config=my_config,
@@ -249,7 +254,8 @@ class TestTransformerManager(ResourceTestBase):
 
         client = self._test_client(transformation_manager=transformer,
                                    rabbit_adaptor=mock_rabbit_adaptor,
-                                   additional_config={'TRANSFORMER_CPU_LIMIT': 30})
+                                   additional_config={'TRANSFORMER_CPU_LIMIT': 1,
+                                                      'TRANSFORMER_CPU_SCALE_THRESHOLD': 30})
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(


### PR DESCRIPTION
PR to enable configuration of the CPU threshold metric (previously hardcoded to 1%). Now determined from the yaml at the time of deployment.