### PR TITLE
Add Prometheus exporter

### DIFF
--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -34,6 +34,7 @@ from flask import Flask
 from flask_bootstrap import Bootstrap
 from flask_jwt_extended import (JWTManager)
 from flask_restful import Api
+from prometheus_flask_exporter import RESTfulPrometheusMetrics
 
 from servicex.code_gen_adapter import CodeGenAdapter
 from servicex.docker_repo_adapter import DockerRepoAdapter
@@ -84,8 +85,8 @@ def create_app(test_config=None,
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
     Bootstrap(app)
-
     JWTManager(app)
+
     if not test_config:
         app.config.from_envvar('APP_CONFIG_FILE')
     else:
@@ -151,6 +152,7 @@ def create_app(test_config=None,
             docker_repo_adapter = provided_docker_repo_adapter
 
         api = Api(app)
+        metrics = RESTfulPrometheusMetrics(app, api)
 
         # ensure the instance folder exists
         try:
@@ -166,6 +168,6 @@ def create_app(test_config=None,
 
         add_routes(api, transformer_manager, rabbit_adaptor, object_store,
                    elasticsearch_adaptor, code_gen_service, lookup_result_processor,
-                   docker_repo_adapter)
+                   docker_repo_adapter, metrics)
 
     return app

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -30,7 +30,7 @@ from flask import current_app as app
 
 def add_routes(api, transformer_manager, rabbit_mq_adaptor,
                object_store, elasticsearch_adapter, code_gen_service,
-               lookup_result_processor, docker_repo_adapter):
+               lookup_result_processor, docker_repo_adapter, metrics):
     from servicex.resources.submit_transformation_request import SubmitTransformationRequest
     from servicex.resources.transform_start import TransformStart
     from servicex.resources.transform_status \

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setup(
         'psycopg2',
         'globus_sdk',
         'cryptography',
-        'bootstrap-flask'
+        'bootstrap-flask',
+        'prometheus-flask-exporter'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Export metrics from Flask to Prometheus via the confusingly-named [Prometheus Flask exporter](https://github.com/rycus86/prometheus_flask_exporter). By default this will simply track HTTP requests, but we can also add custom metrics.

ssl-hep/ServiceX#187 includes a ServiceMonitor for the Flask app, which the Prometheus Operator uses to configure Prometheus to scrape these metrics.

WIP: need to make sure API endpoints are being tracked/exported properly.