### PR TITLE
Clean up obsolete methods on ServiceXResource class

### DIFF
--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -90,27 +90,6 @@ class ServiceXResource(Resource):
             return False, "Signatures did not match"
 
     @staticmethod
-    def _validate_user_is_admin():
-        """
-        Determine if the session should allow the user request in. Use this to guard
-        endpoints that are only accessable to admin users
-        :return: Tuple of Boolean indicating whether the permission is granted and
-        a string message of why it is rejected
-        """
-        if not current_app.config['ENABLE_AUTH']:
-            return True, None
-        try:
-            user = UserModel.find_by_sub(get_jwt_identity())
-            if user and user.admin:
-                return True, None
-            else:
-                return False, "User is not permitted to perform this operation"
-        except Exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            print(exc_value)
-            return False, str(exc_value)
-
-    @staticmethod
     def _generate_file_status_record(dataset_file, status):
         time = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -26,15 +26,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import sys
-import time
-import hashlib
-import hmac
 
 from flask_jwt_extended import get_jwt_identity
 from flask_restful import Resource
 from flask import current_app
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 
 from servicex.models import TransformationResult, UserModel
 
@@ -66,28 +62,6 @@ class ServiceXResource(Resource):
             exc_type, exc_value, exc_traceback = sys.exc_info()
             print(exc_value)
             return False, str(exc_value)
-
-    @staticmethod
-    def _verify_slack_request(req):
-        secret = current_app.config.get('SLACK_SIGNING_SECRET')
-        if not secret:
-            return False, "No Slack app configured"
-
-        body = req.get_data().decode('utf-8')
-
-        timestamp = req.headers['X-Slack-Request-Timestamp']
-        if time.time() - float(timestamp) > 60 * 5:
-            return False, "Request is expired"
-
-        sig_basestring = f"v0:{timestamp}:{body}".encode('utf-8')
-        signature = "v0=" + hmac.new(secret.encode('utf-8'),
-                                     sig_basestring,
-                                     digestmod=hashlib.sha256).hexdigest()
-        slack_signature = req.headers['X-Slack-Signature']
-        if hmac.compare_digest(signature, slack_signature):
-            return True, None
-        else:
-            return False, "Signatures did not match"
 
     @staticmethod
     def _generate_file_status_record(dataset_file, status):

--- a/servicex/resources/users/pending_users.py
+++ b/servicex/resources/users/pending_users.py
@@ -33,16 +33,8 @@ from servicex.models import UserModel
 class PendingUsers(ServiceXResource):
     @admin_required
     def get(self):
-        is_auth, auth_reject_message = self._validate_user_is_admin()
-        if not is_auth:
-            return {'message': f'Authentication Failed: {str(auth_reject_message)}'}, 401
-        else:
-            return UserModel.return_all_pending()
+        return UserModel.return_all_pending()
 
     @admin_required
     def delete(self):
-        is_auth, auth_reject_message = self._validate_user_is_admin()
-        if not is_auth:
-            return {'message': f'Authentication Failed: {str(auth_reject_message)}'}, 401
-        else:
-            return UserModel.delete_all_pending()
+        return UserModel.delete_all_pending()


### PR DESCRIPTION
- Removed `ServiceXResource._validate_is_admin` (redundant alongside `@admin_required` decorator)
- Removed `ServiceXResource._verify_slack_request` (this code is specific to the `/slack` endpoint, and was moved there a while ago, so the method was unused).

May follow up with a PR to replace the `ServiceXResource._validate_user` method with an `@auth_required` decorator, for consistency and because decorators are slightly easier to test.