### PR TITLE
Hide auth-related links when auth is disabled

### DIFF
--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -36,7 +36,8 @@
           <a class="nav-item nav-link" href="https://mweinberg2718.github.io/ServiceX_frontend/">Docs</a>
         </div>
         <!-- Navbar Right Side -->
-        <div class="navbar-nav">
+        {% if config['ENABLE_AUTH'] %}
+          <div class="navbar-nav">
           {% if not session['is_authenticated'] %}
             <a href="/sign-in" class="nav-item nav-link">Sign In</a>
           {% else %}
@@ -46,6 +47,7 @@
             </a>
           {% endif %}
         </div>
+        {% endif %}
       </div>
     </div>
   </nav>


### PR DESCRIPTION
This is something of a band-aid, since the routes are still registered and can be reached via url manipulation (although they won't work).

The most correct thing to do is to only register the routes if auth is enabled, but this requires some nontrivial updates to the test suite.