### PR TITLE
Fix bug in auth decorators

### DIFF
--- a/servicex/decorators.py
+++ b/servicex/decorators.py
@@ -33,11 +33,7 @@ def auth_required(fn: Callable[..., Response]) -> Callable[..., Response]:
     Pending or deleted users will receive a 401: Unauthorized response.
     """
 
-    if not current_app.config.get('ENABLE_AUTH'):
-        return fn
-
-    @wraps(fn)
-    def decorated_function(*args, **kwargs) -> Response:
+    def inner(*args, **kwargs) -> Response:
         user = UserModel.find_by_sub(get_jwt_identity())
         if not user:
             msg = 'Not Authorized: No user found matching this API token. ' \
@@ -51,21 +47,31 @@ def auth_required(fn: Callable[..., Response]) -> Callable[..., Response]:
             return make_response({'message': msg}, 401)
         return fn(*args, **kwargs)
 
-    return jwt_required(decorated_function)
+    @wraps(fn)
+    def decorated(*args, **kwargs) -> Callable[..., Response]:
+        if not current_app.config.get('ENABLE_AUTH'):
+            return fn(*args, **kwargs)
+        # Wrap with jwt_required as well if auth is enabled
+        return jwt_required(inner)(*args, **kwargs)
+
+    return decorated
 
 
 def admin_required(fn: Callable[..., Response]) -> Callable[..., Response]:
     """Mark an API resource as requiring administrator role."""
 
-    if not current_app.config.get('ENABLE_AUTH'):
-        return fn
-
-    @wraps(fn)
-    def decorated_function(*args, **kwargs) -> Response:
+    def inner(*args, **kwargs) -> Response:
         user = UserModel.find_by_sub(get_jwt_identity())
         msg = 'Not Authorized: This resource is restricted to administrators.'
         if not (user and user.admin):
             return make_response({'message': msg}, 401)
         return fn(*args, **kwargs)
 
-    return jwt_required(decorated_function)
+    @wraps(fn)
+    def decorated(*args, **kwargs) -> Callable[..., Response]:
+        if not current_app.config.get('ENABLE_AUTH'):
+            return fn(*args, **kwargs)
+        # Wrap with jwt_required as well if auth is enabled
+        return jwt_required(inner)(*args, **kwargs)
+
+    return decorated

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -55,7 +55,7 @@ class TestDecorators(WebTestBase):
             response: Response = decorated()
             assert response.status_code == 200
 
-    def test_auth_decorator_user_deleted(self, mocker):
+    def test_auth_decorator_user_deleted(self, mocker, mock_jwt_required):
         mocker.patch('servicex.decorators.UserModel.find_by_sub',
                      return_value=None)
         client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})


### PR DESCRIPTION
Currently, any deployment made from the develop branch is rejecting all requests to a resource protected with the `@auth_required` decorator. The root cause seems to be that `get_jwt_identity()` returns None, probably because it only works inside of a function wrapped by the `jwt_required` decorator from Flask-JWT-extended, and I moved the call to `jwt_required` to the wrong place in a previous commit when I was trying to make the tests work (I don't remember why I felt the move was necessary; the tests work fine with these changes).

This PR fixes the logic of the `auth_required` and `admin_required` decorators. The control flow looks like this:
- If auth is not enabled, these decorators are a no-op (they act as the identity function)
- If auth is enabled, an inner function is defined which performs the desired checks
- ~~The inner function is wrapped with jwt_required, which throws `flask_jwt_extended.exceptions.NoAuthorizationError: Missing Authorization Header` if no access token is present in the Authorization header. Currently, this results in a response of 500 Internal Server Error being sent to the client instead of 401 Unauthorized. This is a bug in the way Flask-RESTful handles exceptions (see vimalloc/flask-jwt-extended#86). A proposed fix is to replace Flask-RESTful with Flask-Restx, but that's out of the scope of this PR (see #55).~~ Seems like this is working correctly based on the integration tests.