### PR TITLE
Use DOCS_BASE_URL config value for links to docs

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -4,6 +4,9 @@
 # details are beyond the scope of this example
 SECRET_KEY = 'abc123!'
 
+# Base URL of documentation
+DOCS_BASE_URL = 'https://servicex.readthedocs.io/en/latest/'
+
 # Enable JWT auth on public endpoints
 ENABLE_AUTH=False
 

--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -33,7 +33,10 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarToggle">
         <div class="navbar-nav mr-auto">
-          <a class="nav-item nav-link" href="https://mweinberg2718.github.io/ServiceX_frontend/">Docs</a>
+          <a class="nav-item nav-link"
+             href="{{ config['DOCS_BASE_URL'] }}">
+            Docs
+          </a>
         </div>
         <!-- Navbar Right Side -->
         {% if config['ENABLE_AUTH'] %}

--- a/servicex/templates/emails/welcome.html
+++ b/servicex/templates/emails/welcome.html
@@ -7,12 +7,12 @@
 </div>
 <ul>
   <li>
-    <a href="https://mweinberg2718.github.io/ServiceX_frontend/installation/">
+    <a href="{{ config['DOCS_BASE_URL'] }}installation/">
       Installation instructions
     </a>
   </li>
   <li>
-    <a href="https://mweinberg2718.github.io/ServiceX_frontend/requests/">
+    <a href="{{ config['DOCS_BASE_URL'] }}requests/">
       How to make requests
     </a>
   </li>


### PR DESCRIPTION
In ssl-hep/ServiceX#197, we make it possible to specify the URL of the documentation for each deployment. This PR updates the Flask app so that this URL is used in the header and welcome emails, instead of the previously hardcoded values.