### PR TITLE
Default Transformer Image and other system info

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -59,6 +59,9 @@ TRANSFORMER_MANAGER_MODE = 'external-kubernetes'
 TRANSFORMER_VALIDATE_DOCKER_IMAGE = True
 
 TRANSFORMER_MESSAGING = 'none'
+
+TRANSFORMER_DEFAULT_IMAGE = "sslhep/servicex_func_adl_xaod_transformer:develop"
+
 OBJECT_STORE_ENABLED = False
 MINIO_URL = 'localhost:9000'
 MINIO_ACCESS_KEY = 'miniouser'
@@ -68,6 +71,7 @@ MINIO_SECRET_KEY = 'leftfoot1'
 MINIO_PUBLIC_URL = 'localhost:9000'
 
 CODE_GEN_SERVICE_URL = 'http://localhost:5001'
+CODE_GEN_IMAGE = "sslhep/servicex_code_gen_func_adl_xaod:develop"
 
 ELASTIC_SEARCH_LOGGING_ENABLED = False
 ES_HOST = 'host'

--- a/migrations/versions/dd1f9a8a2aee_v1_0_rc_3.py
+++ b/migrations/versions/dd1f9a8a2aee_v1_0_rc_3.py
@@ -40,6 +40,8 @@ def upgrade():
     op.add_column('requests', sa.Column('submitted_by', sa.Integer()))
     op.create_foreign_key('requests_submitted_by_fkey', 'requests', 'users', ['submitted_by'], ['id'])
 
+    op.add_column('requests', sa.Column('app_version', sa.String(length=64), nullable=True))
+    op.add_column('requests', sa.Column('code_gen_image', sa.String(length=256), nullable=True))
 
 def downgrade():
     op.drop_constraint('requests_submitted_by_fkey', 'requests', type_='foreignkey')
@@ -61,3 +63,6 @@ def downgrade():
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('email')
     )
+
+    op.drop_column('requests', 'app_version')
+    op.drop_column('requests', 'code_gen_image')

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -161,6 +161,8 @@ class TransformRequest(db.Model):
     generated_code_cm = db.Column(db.String(128), nullable=True)
     status = db.Column(db.String(128), nullable=True)
     failure_description = db.Column(db.String(max_string_size), nullable=True)
+    app_version = db.Column(db.String(64), nullable=True)
+    code_gen_image = db.Column(db.String(256), nullable=True)
 
     def save_to_db(self):
         db.session.add(self)
@@ -182,7 +184,9 @@ class TransformRequest(db.Model):
             'workflow-name': self.workflow_name,
             'generated-code-cm': self.generated_code_cm,
             'status': self.status,
-            'failure-info': self.failure_description
+            'failure-info': self.failure_description,
+            'app-version': self.app_version,
+            'code-gen-image': self.code_gen_image
         }
 
     @classmethod

--- a/servicex/resources/info.py
+++ b/servicex/resources/info.py
@@ -25,53 +25,14 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import io
+from resources.servicex_resource import ServiceXResource
+from flask import current_app
 
-from setuptools import find_packages, setup
 
-with io.open('README.rst', 'rt', encoding='utf8') as f:
-    readme = f.read()
-
-setup(
-    name='servicex_app',
-    version='1.0.0-RC.3',
-    url='https://iris-hep.org',
-    license='BSD',
-    maintainer='ServiceX Team',
-    maintainer_email='bengal1@illinois.edu',
-    description='REST Frontend to ServiceX.',
-    long_description=readme,
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=[
-        'flask',
-        'Flask-WTF',
-        'wtforms',
-        'email-validator',
-        'pika',
-        'flask-restful',
-        'flask-jwt-extended',
-        'passlib',
-        'flask-sqlalchemy',
-        'Flask-Migrate',
-        'confluent_kafka',
-        'kubernetes',
-        'minio',
-        'elasticsearch',
-        'psycopg2',
-        'globus_sdk',
-        'cryptography',
-        'bootstrap-flask'
-    ],
-    extras_require={
-        'test': [
-            'pytest>=5.2',
-            'pytest-flask==1.0.0',
-            'coverage>=5.2',
-            'codecov==2.1.8',
-            'pytest-mock==3.2.0',
-            'flake8>=3.8'
-        ],
-    },
-)
+class Info(ServiceXResource):
+    def get(self):
+        return {
+            "app-version": self._get_app_version(),
+            "default-transformer": current_app.config['TRANSFORMER_DEFAULT_IMAGE'],
+            "code-gen-image": current_app.config['CODE_GEN_IMAGE']
+        }

--- a/servicex/resources/info.py
+++ b/servicex/resources/info.py
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from resources.servicex_resource import ServiceXResource
+from servicex.resources.servicex_resource import ServiceXResource
 from flask import current_app
 
 

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -28,6 +28,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
+import pkg_resources
 from flask import current_app
 from flask_jwt_extended import get_jwt_identity
 from flask_restful import Resource
@@ -94,3 +95,15 @@ class ServiceXResource(Resource):
             "status": status,
             "info": ' '
         }
+
+    @classmethod
+    def _get_app_version(cls):
+        """
+        Examine installed packages to get the version number for the ServiceX App
+        :return: The version number, or the string "develop" if servicex_app not installed
+        """
+        try:
+            app_version = pkg_resources.get_distribution('servicex_app').version
+            return app_version
+        except pkg_resources.DistributionNotFound:
+            return "develop"

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -43,6 +43,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.resources.fileset_complete import FilesetComplete
     from servicex.resources.transformer_file_complete import TransformerFileComplete
     from servicex.resources.transform_errors import TransformErrors
+    from servicex.resources.info import Info
 
     from servicex.resources.users.all_users import AllUsers
     from servicex.resources.users.token_refresh import TokenRefresh
@@ -85,6 +86,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     api.add_resource(SlackInteraction, '/slack')
 
     # Client public endpoints
+    api.add_resource(Info, '/servicex')
     api.add_resource(SubmitTransformationRequest, '/servicex/transformation')
 
     api.add_resource(AllTransformationRequests, '/servicex/transformation')

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -60,7 +60,9 @@ class ResourceTestBase:
             'ENABLE_AUTH': False,
             'JWT_ADMIN': 'admin@example.com',
             'JWT_PASS': 'pass',
-            'JWT_SECRET_KEY': 'schtum'
+            'JWT_SECRET_KEY': 'schtum',
+            'TRANSFORMER_DEFAULT_IMAGE': "sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3",
+            'CODE_GEN_IMAGE': "sslhep/servicex_code_gen_func_adl_xaod:develop"
         }
 
     @staticmethod
@@ -102,6 +104,8 @@ class ResourceTestBase:
         transform_request.total_events = 10000
         transform_request.total_bytes = 1203
         transform_request.status = "Submitted"
+        transform_request.app_version = '1.0.1'
+        transform_request.code_gen_image = "sslhep/servicex_code_gen_func_adl_xaod:develop"
         return transform_request
 
     @fixture
@@ -135,3 +139,10 @@ class ResourceTestBase:
             'servicex.resources.servicex_resource.UserModel.find_by_sub',
             return_value=mock_user)
         return mock_user
+
+    @fixture
+    def mock_app_version(self, mocker):
+        from servicex.resources.servicex_resource import ServiceXResource
+        mocker.patch.object(ServiceXResource,
+                            "_get_app_version",
+                            return_value='3.14.15')

--- a/tests/resources/test_servicex_info.py
+++ b/tests/resources/test_servicex_info.py
@@ -29,11 +29,11 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestServicexInfo(ResourceTestBase):
-    def test_get_info(self, mocker, mock_rabbit_adaptor):
+    def test_get_info(self, mock_app_version, mock_rabbit_adaptor):
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         response = client.get('/servicex')
         assert response.status_code == 200
         print(response.json)
-        assert response.json == {'app-version': 'develop',
+        assert response.json == {'app-version': '3.14.15',
                                  'default-transformer': 'sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3',  # noqa: E501
                                  'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'}  # noqa: E501

--- a/tests/resources/test_servicex_info.py
+++ b/tests/resources/test_servicex_info.py
@@ -25,53 +25,15 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import io
+from tests.resource_test_base import ResourceTestBase
 
-from setuptools import find_packages, setup
 
-with io.open('README.rst', 'rt', encoding='utf8') as f:
-    readme = f.read()
-
-setup(
-    name='servicex_app',
-    version='1.0.0-RC.3',
-    url='https://iris-hep.org',
-    license='BSD',
-    maintainer='ServiceX Team',
-    maintainer_email='bengal1@illinois.edu',
-    description='REST Frontend to ServiceX.',
-    long_description=readme,
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=[
-        'flask',
-        'Flask-WTF',
-        'wtforms',
-        'email-validator',
-        'pika',
-        'flask-restful',
-        'flask-jwt-extended',
-        'passlib',
-        'flask-sqlalchemy',
-        'Flask-Migrate',
-        'confluent_kafka',
-        'kubernetes',
-        'minio',
-        'elasticsearch',
-        'psycopg2',
-        'globus_sdk',
-        'cryptography',
-        'bootstrap-flask'
-    ],
-    extras_require={
-        'test': [
-            'pytest>=5.2',
-            'pytest-flask==1.0.0',
-            'coverage>=5.2',
-            'codecov==2.1.8',
-            'pytest-mock==3.2.0',
-            'flake8>=3.8'
-        ],
-    },
-)
+class TestServicexInfo(ResourceTestBase):
+    def test_get_info(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        response = client.get('/servicex')
+        assert response.status_code == 200
+        print(response.json)
+        assert response.json == {'app-version': 'develop',
+                                 'default-transformer': 'sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3',  # noqa: E501
+                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'}  # noqa: E501

--- a/tests/resources/test_servicex_resource.py
+++ b/tests/resources/test_servicex_resource.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pkg_resources
+
+
+class TestServiceXResource:
+    def test_get_app_version_no_servicex_app(self, mocker):
+        mock_get_distribution = mocker.patch(
+            "servicex.resources.servicex_resource.pkg_resources.get_distribution",
+            side_effect=pkg_resources.DistributionNotFound(None, None))
+
+        from servicex.resources.servicex_resource import ServiceXResource
+        version = ServiceXResource._get_app_version()
+
+        mock_get_distribution.assert_called_with("servicex_app")
+        assert version == 'develop'

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -25,7 +25,9 @@ class TestTransformationRequest(ResourceTestBase):
                                  'workflow-name': None,
                                  'generated-code-cm': None,
                                  'status': "Submitted",
-                                 'failure-info': None
+                                 'failure-info': None,
+                                 'app-version': "1.0.1",
+                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
                                  }
         mock_transform_request_read.assert_called_with('1234')
 
@@ -64,7 +66,9 @@ class TestTransformationRequest(ResourceTestBase):
                                  'workflow-name': None,
                                  'generated-code-cm': None,
                                  'status': "Submitted",
-                                 'failure-info': None
+                                 'failure-info': None,
+                                 'app-version': "1.0.1",
+                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
                                  }
 
         mock_transform_request_read.assert_called_with('1234')
@@ -100,7 +104,9 @@ class TestTransformationRequest(ResourceTestBase):
                                  'workflow-name': None,
                                  'generated-code-cm': None,
                                  'status': "Submitted",
-                                 'failure-info': None
+                                 'failure-info': None,
+                                 'app-version': "1.0.1",
+                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
                                  }
 
         mock_transform_request_read.assert_called_with('1234')

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -1,122 +1,456 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+from unittest.mock import call
+
+from servicex import ElasticSearchAdapter, LookupResultProcessor
+from servicex.models import TransformRequest
 from tests.resource_test_base import ResourceTestBase
 
 
-class TestTransformationRequest(ResourceTestBase):
+class TestSubmitTransformationRequest(ResourceTestBase):
 
-    def test_get_single_request_no_object_store(self, mocker,
-                                                mock_rabbit_adaptor):
-        import servicex
-        mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest,
-            'return_request',
-            return_value=self._generate_transform_request())
-        client = self._test_client(extra_config={'OBJECT_STORE_ENABLED': False},
-                                   rabbit_adaptor=mock_rabbit_adaptor)
-        response = client.get('/servicex/transformation/1234')
-        assert response.status_code == 200
-        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
-                                 'columns': 'electron.eta(), muon.pt()',
-                                 'selection': None,
-                                 'tree-name': "Events",
-                                 'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
-                                 'workers': 42, 'result-destination': 'kafka',
-                                 'result-format': 'arrow',
-                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
-                                 'workflow-name': None,
-                                 'generated-code-cm': None,
-                                 'status': "Submitted",
-                                 'failure-info': None,
-                                 'app-version': "1.0.1",
-                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
-                                 }
-        mock_transform_request_read.assert_called_with('1234')
-
-    def test_get_single_request_with_object_store(self, mocker, mock_rabbit_adaptor):
-        import servicex
-        object_store_transform_request = self._generate_transform_request()
-        object_store_transform_request.result_destination = 'object-store'
-        mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest,
-            'return_request',
-            return_value=object_store_transform_request)
-
-        local_config = {
-            'OBJECT_STORE_ENABLED': True,
-            'MINIO_PUBLIC_URL': 'minio.servicex.com:9000',
-            'MINIO_ACCESS_KEY': 'miniouser',
-            'MINIO_SECRET_KEY': 'leftfoot1'
-        }
-
-        client = self._test_client(extra_config=local_config,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
-        response = client.get('/servicex/transformation/1234')
-        assert response.status_code == 200
-        print(response.json)
-        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
-                                 'columns': 'electron.eta(), muon.pt()',
-                                 'selection': None,
-                                 'tree-name': "Events",
-                                 'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
-                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
-                                 'workers': 42, 'result-destination': 'object-store',
-                                 'result-format': 'arrow',
-                                 'minio-access-key': 'miniouser',
-                                 'minio-endpoint': 'minio.servicex.com:9000',
-                                 'minio-secret-key': 'leftfoot1',
-                                 'workflow-name': None,
-                                 'generated-code-cm': None,
-                                 'status': "Submitted",
-                                 'failure-info': None,
-                                 'app-version': "1.0.1",
-                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
-                                 }
-
-        mock_transform_request_read.assert_called_with('1234')
-
-    def test_get_single_request_to_kafka(self, mocker, mock_rabbit_adaptor):
-        import servicex
-        kafka_transform_request = self._generate_transform_request()
-        kafka_transform_request.result_destination = 'kafka'
-        mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest,
-            'return_request',
-            return_value=kafka_transform_request)
-
-        local_config = {
-            'OBJECT_STORE_ENABLED': True,
-            'MINIO_PUBLIC_URL': 'minio.servicex.com:9000',
-            'MINIO_ACCESS_KEY': 'miniouser',
-            'MINIO_SECRET_KEY': 'leftfoot1'
-        }
-
-        client = self._test_client(extra_config=local_config,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
-        response = client.get('/servicex/transformation/1234')
-        assert response.status_code == 200
-        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
-                                 'columns': 'electron.eta(), muon.pt()',
-                                 'selection': None,
-                                 'tree-name': "Events",
-                                 'image': 'ssl-hep/foo:latest', 'chunk-size': 1000,
-                                 'kafka-broker': 'http://ssl-hep.org.kafka:12345',
-                                 'workers': 42, 'result-destination': 'kafka',
-                                 'result-format': 'arrow',
-                                 'workflow-name': None,
-                                 'generated-code-cm': None,
-                                 'status': "Submitted",
-                                 'failure-info': None,
-                                 'app-version': "1.0.1",
-                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
-                                 }
-
-        mock_transform_request_read.assert_called_with('1234')
-
-    def test_get_single_request_404(self, mocker, mock_rabbit_adaptor):
-        import servicex
-        mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest, 'return_request',
-            return_value=None)
+    def test_submit_transformation_request_bad(self, mocker, mock_rabbit_adaptor):
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
-        response = client.get('/servicex/transformation/1234')
-        assert response.status_code == 404
-        mock_transform_request_read.assert_called_with('1234')
+        response = client.post('/servicex/transformation',
+                               json={'timestamp': '20190101'})
+        assert response.status_code == 400
+
+    @staticmethod
+    def _generate_transformation_request():
+        return {'did': '123-45-678',
+                'columns': "e.e, e.p",
+                'image': 'ssl-hep/foo:latest',
+                'result-destination': 'kafka',
+                'kafka': {
+                    'broker': 'ssl.hep.kafka:12332'
+                },
+                'chunk-size': 500,
+                'workers': 10}
+
+    @staticmethod
+    def _generate_transformation_request_xAOD_root_file():
+        return {'did': '123-45-678',
+                'selection': "test-string",
+                'image': 'ssl-hep/func_adl:latest',
+                'result-destination': 'object-store',
+                'result-format': 'root-file',
+                'workers': 10}
+
+    def test_submit_transformation_bad_result_dest(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        request = self._generate_transformation_request()
+        request['result-destination'] = 'foo'
+        response = client.post('/servicex/transformation', json=request)
+        assert response.status_code == 400
+
+    def test_submit_transformation_bad_wrong_dest_for_format(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        request = self._generate_transformation_request()
+        request['result-format'] = 'root-file'
+        request['result-destination'] = 'minio'
+        response = client.post('/servicex/transformation', json=request)
+        assert response.status_code == 400
+
+    def test_submit_transformation_bad_result_format(self, mocker, mock_rabbit_adaptor):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        request = self._generate_transformation_request()
+        request['result-format'] = 'foo'
+        response = client.post('/servicex/transformation', json=request)
+        assert response.status_code == 400
+
+    def test_submit_transformation_bad_workflow(self, mock_rabbit_adaptor,
+                                                mock_docker_repo_adapter):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+        request = self._generate_transformation_request()
+        request['columns'] = None
+        request['selection'] = None
+
+        r = client.post('/servicex/transformation', json=request)
+        assert r.status_code == 400
+
+    def test_submit_transformation_request_throws_exception(self, mocker,
+                                                            mock_rabbit_adaptor,
+                                                            mock_docker_repo_adapter):
+        mock_rabbit_adaptor.setup_queue = mocker.Mock(side_effect=Exception('Test'))
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+        assert response.status_code == 500
+        assert response.json == {"message": "Something went wrong"}
+
+    def test_submit_transformation(self, mock_rabbit_adaptor,
+                                   mock_docker_repo_adapter,
+                                   mock_app_version):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+
+        assert response.status_code == 200
+
+        request_id = response.json['request_id']
+
+        with client.application.app_context():
+            saved_obj = TransformRequest.return_request(request_id)
+            assert saved_obj
+            assert saved_obj.did == '123-45-678'
+            assert saved_obj.request_id == request_id
+            assert saved_obj.columns == "e.e, e.p"
+            assert saved_obj.image == 'ssl-hep/foo:latest'
+            assert saved_obj.chunk_size == 500
+            assert saved_obj.workers == 10
+            assert saved_obj.result_destination == 'kafka'
+            assert saved_obj.kafka_broker == "ssl.hep.kafka:12332"
+            assert saved_obj.app_version == "3.14.15"
+            assert saved_obj.code_gen_image == 'sslhep/servicex_code_gen_func_adl_xaod:develop'
+
+        setup_queue_calls = [call(request_id), call(request_id+"_errors")]
+        mock_rabbit_adaptor.setup_queue.assert_has_calls(setup_queue_calls)
+
+        bind_to_exchange_calls = [
+            call(exchange="transformation_requests", queue=request_id),
+            call(exchange="transformation_failures", queue=request_id+"_errors"),
+
+        ]
+
+        assert mock_rabbit_adaptor.bind_queue_to_exchange.call_args_list == bind_to_exchange_calls
+
+        service_endpoint = \
+            "http://cern.analysis.ch:5000/servicex/internal/transformation/" + \
+            request_id
+
+        mock_rabbit_adaptor. \
+            basic_publish.assert_called_with(exchange='',
+                                             routing_key='did_requests',
+                                             body=json.dumps(
+                                                 {
+                                                     "request_id": request_id,
+                                                     "did": "123-45-678",
+                                                     "service-endpoint": service_endpoint}
+                                             ))
+
+    def test_submit_transformation_with_root_file(self, mocker,
+                                                  mock_rabbit_adaptor,
+                                                  mock_code_gen_service,
+                                                  mock_docker_repo_adapter,
+                                                  mock_app_version):
+        mock_code_gen_service.generate_code_for_selection = mocker.Mock(return_value='my-cm')
+        request = self._generate_transformation_request_xAOD_root_file()
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 200
+
+        request_id = response.json['request_id']
+
+        with client.application.app_context():
+            saved_obj = TransformRequest.return_request(request_id)
+            assert saved_obj
+            assert saved_obj.did == '123-45-678'
+            assert saved_obj.request_id == request_id
+            assert saved_obj.columns is None
+            assert saved_obj.selection == 'test-string'
+            assert saved_obj.image == 'ssl-hep/func_adl:latest'
+            assert saved_obj.chunk_size is None
+            assert saved_obj.workers == 10
+            assert saved_obj.result_destination == 'object-store'
+            assert saved_obj.result_format == 'root-file'
+            assert saved_obj.generated_code_cm == 'my-cm'
+            assert saved_obj.app_version == "3.14.15"
+            assert saved_obj.code_gen_image == 'sslhep/servicex_code_gen_func_adl_xaod:develop'
+
+        setup_queue_calls = [call(request_id), call(request_id+"_errors")]
+        mock_rabbit_adaptor.setup_queue.assert_has_calls(setup_queue_calls)
+
+        bind_to_exchange_calls = [
+            call(exchange="transformation_requests", queue=request_id),
+            call(exchange="transformation_failures", queue=request_id+"_errors"),
+
+        ]
+
+        assert mock_rabbit_adaptor.bind_queue_to_exchange.call_args_list == bind_to_exchange_calls
+
+        service_endpoint = \
+            "http://cern.analysis.ch:5000/servicex/internal/transformation/" + \
+            request_id
+
+        mock_rabbit_adaptor. \
+            basic_publish.assert_called_with(exchange='',
+                                             routing_key='did_requests',
+                                             body=json.dumps(
+                                                 {
+                                                     "request_id": request_id,
+                                                     "did": "123-45-678",
+                                                     "service-endpoint": service_endpoint}
+                                             ))
+
+    def test_submit_transformation_file_list(self, mocker,
+                                             mock_rabbit_adaptor,
+                                             mock_code_gen_service,
+                                             mock_docker_repo_adapter):
+        request = self._generate_transformation_request()
+        request['did'] = None
+        request['file-list'] = ["file1", "file2"]
+
+        mock_processor = mocker.MagicMock(LookupResultProcessor)
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service,
+                                   lookup_result_processor=mock_processor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 200
+
+        mock_processor.publish_preflight_request.assert_called_once()
+        preflight_call = mock_processor.publish_preflight_request.call_args
+        assert preflight_call[0][1] == 'file1'
+
+        mock_processor.add_file_to_dataset.assert_called()
+        add_file_calls = mock_processor.add_file_to_dataset.call_args_list
+        assert mock_processor.add_file_to_dataset.call_count == 2
+        assert add_file_calls[0][0][1].file_path == 'file1'
+        assert add_file_calls[1][0][1].file_path == 'file2'
+
+        mock_processor.report_fileset_complete.assert_called()
+        fileset_complete_call = mock_processor.report_fileset_complete.call_args
+        assert fileset_complete_call[1]['num_files'] == 2
+
+    def test_submit_transformation_request_bad_image(self, mocker,
+                                                     mock_rabbit_adaptor,
+                                                     mock_docker_repo_adapter):
+
+        mock_docker_repo_adapter.check_image_exists = mocker.Mock(return_value=False)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+        assert response.status_code == 400
+        assert response.json == {"message": "The requested transformer docker image doesn't exist: ssl-hep/foo:latest"}  # noqa: E501
+
+    def test_submit_transformation_request_no_docker_check(self, mocker,
+                                                           mock_rabbit_adaptor,
+                                                           mock_docker_repo_adapter):
+
+        mock_docker_repo_adapter.check_image_exists = mocker.Mock(return_value=False)
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter,
+                                   extra_config={
+                                       'TRANSFORMER_VALIDATE_DOCKER_IMAGE': False}
+                                   )
+
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+        assert response.status_code == 200
+        mock_docker_repo_adapter.check_image_exists.assert_not_called()
+
+    def test_submit_transformation_with_root_file_selection_error(self, mocker,
+                                                                  mock_rabbit_adaptor,
+                                                                  mock_code_gen_service):
+        mock_code_gen_service.generate_code_for_selection = \
+                mocker.Mock(side_effect=ValueError('This is the error message'))
+        request = self._generate_transformation_request_xAOD_root_file()
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service)
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 400
+
+    def test_submit_transformation_missing_dataset_source(self, mocker,
+                                                          mock_rabbit_adaptor,
+                                                          mock_code_gen_service):
+        request = self._generate_transformation_request()
+        request['did'] = None
+        request['file-list'] = []
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service)
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 400
+
+    def test_submit_transformation_duplicate_dataset_source(self, mocker,
+                                                            mock_rabbit_adaptor,
+                                                            mock_code_gen_service):
+        request = self._generate_transformation_request()
+        request['did'] = "This did"
+        request['file-list'] = ["file1.root", "file2.root"]
+
+        mock_processor = mocker.MagicMock(LookupResultProcessor)
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   code_gen_service=mock_code_gen_service,
+                                   lookup_result_processor=mock_processor)
+
+        response = client.post('/servicex/transformation',
+                               json=request)
+
+        assert response.status_code == 400
+
+    def test_submit_transformation_with_object_store(self, mocker,
+                                                     mock_rabbit_adaptor,
+                                                     mock_docker_repo_adapter):
+        from servicex import ObjectStoreManager
+
+        local_config = {
+            'OBJECT_STORE_ENABLED': True,
+            'MINIO_URL': 'localhost:9000',
+            'MINIO_ACCESS_KEY': 'miniouser',
+            'MINIO_SECRET_KEY': 'leftfoot1'
+        }
+
+        transformation_request = {'did': '123-45-678',
+                                  'columns': "e.e, e.p",
+                                  'image': 'ssl-hep/foo:latest',
+                                  'result-destination': 'object-store',
+                                  'result-format': 'parquet',
+                                  'chunk-size': 500,
+                                  'workers': 10}
+
+        mock_object_store = mocker.MagicMock(ObjectStoreManager)
+        client = self._test_client(extra_config=local_config,
+                                   rabbit_adaptor=mock_rabbit_adaptor,
+                                   object_store=mock_object_store,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+        response = client.post('/servicex/transformation',
+                               json=transformation_request)
+        assert response.status_code == 200
+
+        request_id = response.json['request_id']
+
+        mock_object_store.create_bucket.assert_called_with(request_id)
+        with client.application.app_context():
+            saved_obj = TransformRequest.return_request(request_id)
+            assert saved_obj
+            assert saved_obj.result_destination == 'object-store'
+            assert saved_obj.result_format == 'parquet'
+
+    def test_submit_transformation_with_elasticsearch(self, mocker,
+                                                      mock_rabbit_adaptor,
+                                                      mock_docker_repo_adapter):
+
+        transformation_request = {'did': '123-45-678',
+                                  'columns': 'electron.eta(), muon.pt()',
+                                  'image': 'ssl-hep/foo:latest',
+                                  'result-destination': 'object-store',
+                                  'result-format': 'parquet',
+                                  'chunk-size': 500,
+                                  'workers': 10}
+
+        mock_elasticsearch_adapter = mocker.MagicMock(ElasticSearchAdapter)
+
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   elasticsearch_adapter=mock_elasticsearch_adapter,
+                                   docker_repo_adapter=mock_docker_repo_adapter)
+
+        response = client.post('/servicex/transformation',
+                               json=transformation_request)
+        assert response.status_code == 200
+
+        path_call = mock_elasticsearch_adapter.create_update_request.mock_calls[0]
+        record_body = path_call[1][1]
+
+        assert record_body['name'] == 'Transformation Request'
+        assert record_body['description'] == 'Transformation Request'
+        assert record_body['dataset'] == '123-45-678'
+        assert record_body['dataset_size'] == 0
+        assert record_body['dataset_files'] == 0
+        assert record_body['dataset_events'] == 0
+        assert record_body['columns'] == 'electron.eta(), muon.pt()'
+        assert record_body['events'] == 0
+        assert record_body['events_transformed'] == 0
+        assert record_body['events_served'] == 0
+        assert record_body['events_processed'] == 0
+        assert record_body['status'] == 'locating DID'
+        assert record_body['info'] == ' '
+
+    def test_submit_transformation_auth_enabled(self, mock_rabbit_adaptor,
+                                                mock_docker_repo_adapter,
+                                                mock_jwt_required,
+                                                mock_requesting_user):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
+                                   docker_repo_adapter=mock_docker_repo_adapter,
+                                   extra_config={'ENABLE_AUTH': True})
+        response = client.post('/servicex/transformation',
+                               json=self._generate_transformation_request())
+
+        assert response.status_code == 200
+
+        request_id = response.json['request_id']
+
+        with client.application.app_context():
+            saved_obj = TransformRequest.return_request(request_id)
+            assert saved_obj
+            assert saved_obj.did == '123-45-678'
+            assert saved_obj.request_id == request_id
+            assert saved_obj.columns == "e.e, e.p"
+            assert saved_obj.image == 'ssl-hep/foo:latest'
+            assert saved_obj.chunk_size == 500
+            assert saved_obj.workers == 10
+            assert saved_obj.result_destination == 'kafka'
+            assert saved_obj.kafka_broker == "ssl.hep.kafka:12332"
+            assert saved_obj.submitted_by == mock_requesting_user.id
+
+        setup_queue_calls = [call(request_id), call(request_id+"_errors")]
+        mock_rabbit_adaptor.setup_queue.assert_has_calls(setup_queue_calls)
+
+        bind_to_exchange_calls = [
+            call(exchange="transformation_requests", queue=request_id),
+            call(exchange="transformation_failures", queue=request_id+"_errors"),
+
+        ]
+
+        assert mock_rabbit_adaptor.bind_queue_to_exchange.call_args_list == bind_to_exchange_calls
+
+        service_endpoint = \
+            "http://cern.analysis.ch:5000/servicex/internal/transformation/" + \
+            request_id
+
+        mock_rabbit_adaptor. \
+            basic_publish.assert_called_with(exchange='',
+                                             routing_key='did_requests',
+                                             body=json.dumps(
+                                                 {
+                                                     "request_id": request_id,
+                                                     "did": "123-45-678",
+                                                     "service-endpoint": service_endpoint}
+                                             ))


### PR DESCRIPTION
# Problem 
The user of serviceX needs to know the transformer image name that matches the deployment. Some users may have strong opinions about this, but most users want the system to know which transformer works best.

Partial solution of [ServiceX Issue 149](https://github.com/ssl-hep/ServiceX/issues/149)

# Approach
1. Add new app.conf value for `TRANSFORMER_DEFAULT_IMAGE`. If no image name is included in the request, this is used.
2. Add a new endpoint for retrieving info about the serviceX deployment. Depends on the Default Image app conf value, as well as a value for `CODE_GEN_IMAGE`. It also retrieves the app version number from the pip installed packages directory.
3. Add new values to the transform request db table to record these settings for each transform to help drive reproducibility.


