### PR TITLE
Fix documentation link in welcome email

### DIFF
--- a/servicex/templates/emails/welcome.html
+++ b/servicex/templates/emails/welcome.html
@@ -3,18 +3,8 @@
   Your ServiceX account has been approved!
 </p>
 <div>
-  Check out these resources to get started:
+  Check out the ServiceX
+  <a href="{{ config['DOCS_BASE_URL'] }}/user/getting-started/">docs</a>
+  to get started!
 </div>
-<ul>
-  <li>
-    <a href="{{ config['DOCS_BASE_URL'] }}installation/">
-      Installation instructions
-    </a>
-  </li>
-  <li>
-    <a href="{{ config['DOCS_BASE_URL'] }}requests/">
-      How to make requests
-    </a>
-  </li>
-</ul>
 </html>


### PR DESCRIPTION
The links to the docs in the welcome email are broken because of a missing slash. Also, the installation.md page no longer exists, and the requests.md page is no longer aimed at brand new users, so we link to getting-started.md instead.