### PR TITLE
Add download button for ServiceX config file

### DIFF
--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -53,7 +53,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.resources.users.slack_interaction import SlackInteraction
 
     from servicex.web import home, sign_in, sign_out, auth_callback, \
-        view_profile, edit_profile, api_token
+        view_profile, edit_profile, api_token, servicex_file
 
     # Must be its own module to allow patching
     from servicex.web.create_profile import create_profile
@@ -71,6 +71,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     app.add_url_rule('/sign-out', 'sign_out', sign_out)
     app.add_url_rule('/auth-callback', 'auth_callback', auth_callback)
     app.add_url_rule('/api-token', 'api_token', api_token)
+    app.add_url_rule('/.servicex', 'servicex-file', servicex_file)
     app.add_url_rule('/profile', 'profile', view_profile)
     app.add_url_rule('/profile/new', 'create_profile', create_profile,
                      methods=['GET', 'POST'])

--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -90,7 +90,7 @@
 <script>
     // Enable tooltips
     $(function () {
-        $('[data-toggle="tooltip"]').tooltip()
+        $('[data-toggle="tooltip"]').tooltip({trigger: 'hover'})
     })
 </script>
 

--- a/servicex/templates/profile.html
+++ b/servicex/templates/profile.html
@@ -31,10 +31,10 @@
       <dt class="col-sm-3">API token</dt>
       <dd class="col-sm-9 row">
         <div class="col" style="word-break: break-all">
-          <code class="text-muted">{{ user.refresh_token }}</code>
+          <code class="text-muted">**********{{ user.refresh_token[-6:] }}</code>
         </div>
-        <div class="d-flex flex-column justify-content-center">
-          <button class="btn btn-sm btn-outline-secondary my-2"
+        <div class="d-flex flex-row justify-content-center">
+          <button class="btn btn-sm btn-outline-secondary"
                   id="copy-btn"
                   type="button"
                   data-value="{{ user.refresh_token }}"
@@ -42,7 +42,15 @@
                   data-toggle="tooltip">
             <i class="fa fa-copy"></i>
           </button>
-          <div class="my-2" data-target="#exampleModal" data-toggle="modal">
+          <a class="mx-3" href="{{ url_for('servicex-file') }}" download>
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary"
+                    title="Download config"
+                    data-toggle="tooltip">
+              <i class="fa fa-download"></i>
+            </button>
+          </a>
+          <div data-target="#exampleModal" data-toggle="modal">
             <button class="btn btn-sm btn-outline-warning"
                     type="button"
                     title="Regenerate"
@@ -100,11 +108,6 @@
                       .tooltip('show')
                       .attr('data-original-title', 'Copy to clipboard');
               });
-      })
-
-      // Hide tooltip on mouseleave, since after clicking it remains focused
-      copyBtn.addEventListener('mouseleave', () => {
-          $('#copy-btn').tooltip('hide');
       })
   </script>
 {% endblock %}

--- a/servicex/web/__init__.py
+++ b/servicex/web/__init__.py
@@ -3,6 +3,7 @@ from .sign_in import sign_in
 from .sign_out import sign_out
 from .auth_callback import auth_callback
 from .api_token import api_token
+from .servicex_file import servicex_file
 from .view_profile import view_profile
 from .edit_profile import edit_profile
 
@@ -14,4 +15,5 @@ __all__ = [
     api_token,
     view_profile,
     edit_profile,
+    servicex_file
 ]

--- a/servicex/web/servicex_file.py
+++ b/servicex/web/servicex_file.py
@@ -14,11 +14,11 @@ def servicex_file():
     code_gen_image = current_app.config.get('CODE_GEN_IMAGE', "")
     candidates = ["xaod", "uproot", "miniaod", "nanoaod"]
     matches = [t for t in candidates if t in code_gen_image]
-    if not matches or len(matches) > 2:
+    if not matches or len(matches) > 1:
         msg = "Could not generate a .servicex config file. " \
               "Unable to infer filetype supported by this ServiceX instance."
         flash(msg, category='error')
-        redirect(url_for('profile'))
+        return redirect(url_for('profile'))
     backend_type = matches[0]
     sub = session.get('sub')
     user = UserModel.find_by_sub(sub)
@@ -26,7 +26,7 @@ def servicex_file():
     api_endpoints:
       - endpoint: {request.url_root}
         token: {user.refresh_token}
-        type: {backend_type} 
+        type: {backend_type}
     """
     return send_file(BytesIO(dedent(body).encode()), mimetype="text/plain",
                      as_attachment=True, attachment_filename=".servicex")

--- a/servicex/web/servicex_file.py
+++ b/servicex/web/servicex_file.py
@@ -29,4 +29,4 @@ def servicex_file():
         type: {backend_type}
     """
     return send_file(BytesIO(dedent(body).encode()), mimetype="text/plain",
-                     as_attachment=True, attachment_filename=".servicex")
+                     as_attachment=True, attachment_filename="servicex.yaml")

--- a/servicex/web/servicex_file.py
+++ b/servicex/web/servicex_file.py
@@ -1,0 +1,32 @@
+from io import BytesIO
+from textwrap import dedent
+
+from flask import current_app, flash, redirect, request, session, url_for, \
+    send_file
+
+from servicex.decorators import oauth_required
+from servicex.models import UserModel
+
+
+@oauth_required
+def servicex_file():
+    """Generate a .servicex config file prepopulated with this endpoint."""
+    code_gen_image = current_app.config.get('CODE_GEN_IMAGE', "")
+    candidates = ["xaod", "uproot", "miniaod", "nanoaod"]
+    matches = [t for t in candidates if t in code_gen_image]
+    if not matches or len(matches) > 2:
+        msg = "Could not generate a .servicex config file. " \
+              "Unable to infer filetype supported by this ServiceX instance."
+        flash(msg, category='error')
+        redirect(url_for('profile'))
+    backend_type = matches[0]
+    sub = session.get('sub')
+    user = UserModel.find_by_sub(sub)
+    body = f"""\
+    api_endpoints:
+      - endpoint: {request.url_root}
+        token: {user.refresh_token}
+        type: {backend_type} 
+    """
+    return send_file(BytesIO(dedent(body).encode()), mimetype="text/plain",
+                     as_attachment=True, attachment_filename=".servicex")

--- a/tests/web/test_servicex_file.py
+++ b/tests/web/test_servicex_file.py
@@ -1,0 +1,37 @@
+from textwrap import dedent
+
+from flask import Response, url_for, get_flashed_messages
+
+from .web_test_base import WebTestBase
+
+
+class TestServiceXFile(WebTestBase):
+    def test_servicex_file(self, client, user):
+        cfg = {'CODE_GEN_IMAGE': 'sslhep/servicex_code_gen_func_adl_xaod:develop'}
+        client.application.config.update(cfg)
+        response: Response = client.get(url_for('servicex-file'))
+        expected = """\
+        api_endpoints:
+          - endpoint: http://localhost/
+            token: abcdef
+            type: xaod
+        """
+        assert response.data.decode() == dedent(expected)
+
+    def test_servicex_file_no_match(self, client):
+        cfg = {'CODE_GEN_IMAGE': 'sslhep/servicex_code_gen_func_adl:develop'}
+        client.application.config.update(cfg)
+        response: Response = client.get(url_for('servicex-file'))
+        assert response.status_code == 302
+        flashed_messages = get_flashed_messages()
+        assert flashed_messages
+        assert "Unable to infer filetype" in flashed_messages[0]
+
+    def test_servicex_file_ambiguous_match(self, client):
+        cfg = {'CODE_GEN_IMAGE': 'sslhep/servicex_code_gen_func_adl_xaod_uproot:develop'}
+        client.application.config.update(cfg)
+        response: Response = client.get(url_for('servicex-file'))
+        assert response.status_code == 302
+        flashed_messages = get_flashed_messages()
+        assert flashed_messages
+        assert "Unable to infer filetype" in flashed_messages[0]

--- a/tests/web/test_servicex_file.py
+++ b/tests/web/test_servicex_file.py
@@ -17,6 +17,7 @@ class TestServiceXFile(WebTestBase):
             type: xaod
         """
         assert response.data.decode() == dedent(expected)
+        assert response.headers['Content-Disposition'] == 'attachment; filename=servicex.yaml'
 
     def test_servicex_file_no_match(self, client):
         cfg = {'CODE_GEN_IMAGE': 'sslhep/servicex_code_gen_func_adl:develop'}

--- a/tests/web/test_sign_in.py
+++ b/tests/web/test_sign_in.py
@@ -3,8 +3,8 @@ from flask import Response, url_for
 from .web_test_base import WebTestBase
 
 
-class TestHome(WebTestBase):
-    def test_home(self, client):
+class TestSignIn(WebTestBase):
+    def test_sign_in(self, client):
         response: Response = client.get(url_for('sign_in'))
         assert response.status_code == 302
         assert response.location == url_for('auth_callback', _external=True)

--- a/tests/web/web_test_base.py
+++ b/tests/web/web_test_base.py
@@ -51,6 +51,7 @@ class WebTestBase:
             'MINIO_URL': 'localhost:9000',
             'MINIO_ACCESS_KEY': 'miniouser',
             'MINIO_SECRET_KEY': 'leftfoot1',
+            'CODE_GEN_IMAGE': 'sslhep/servicex_code_gen_func_adl_xaod:develop',
             'CODE_GEN_SERVICE_URL': 'http://localhost:5001',
             'ENABLE_AUTH': False,
             'GLOBUS_CLIENT_ID': 'globus-client-id',
@@ -80,7 +81,9 @@ class WebTestBase:
             email='jane@example.com',
             sub='janedoe',
             institution='UChicago',
-            experiment='ATLAS')
+            experiment='ATLAS',
+            refresh_token="abcdef"
+        )
 
     @staticmethod
     def _auth_url():


### PR DESCRIPTION
This PR adds a button to the user profiles on the website to enable users to download a ServiceX config file which is prepopulated with the current endpoint. Closes #70.

#### Demo

![](https://i.imgur.com/8NYlbYA.gif)

#### Implementation
- The backend type of the deployment is determined by examining the `CODE_GEN_IMAGE` config value. If it contains exactly one of `"xaod"`, "`miniaod"`, `"nanoaod"`, or "`uproot`", then this is the inferred backend type. For example, `"sslhep/servicex_code_gen_func_adl_xaod:develop"` would result in `type: xaod`. If the image name contains none of these types or more than one, an error message is displayed.

#### Issues
- It seems impossible to send an attachment with a filename prefixed with `.`, as described in [this SO post](https://stackoverflow.com/questions/53107414/flask-how-to-download-a-filename-with-a-dot-prefix). As a result, when we pass the filename `.servicex`, the user receives a file named `servicex` (no `.` prefix). Like the SO poster, I tried a number of solutions - trying to escape or URL-encode the period, constructing the response and `Content-Disposition` header manually, etc. - but I wasn't able to resolve this issue.

One possible solution is to rename `.servicex` files throughout the frontend and backend to `servicex.yaml`. We are already using `.yaml` syntax, so this should be fairly straightforward, but it would be a breaking change. One advantage is that OSs will know to open the file with a text editor, and text editors will recognize the file extension and provide syntax highlighting.

@gordonwatts, thoughts on this proposed change?