### PR TITLE
Allow cluster admins to opt-out of ServiceX user management system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,15 @@ services:
 
 User Management
 ---------------
-If ``ENABLE_AUTH`` is set to True, an identity management system will be
-enabled. Users will need to create accounts in order to make requests.
+If ``ENABLE_AUTH`` is set to True and `DISABLE_USER_MGMT` is False,
+an identity management system will be enabled.
+Users will need to create accounts in order to make requests.
 The system consists of two components: authentication (verification of each
 user's identity) and authorization (control of access to API resources).
+
+If ``ENABLE_AUTH`` and ``DISABLE_USER_MGMT`` are both set to True, then you
+will need to generate your own JWT refresh tokens externally using
+``JWT_SECRET_KEY``, and provide them to end users.
 
 Authentication
 **************

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,11 @@ user's identity) and authorization (control of access to API resources).
 
 If ``ENABLE_AUTH`` and ``DISABLE_USER_MGMT`` are both set to True, then you
 will need to generate your own JWT refresh tokens externally using
-``JWT_SECRET_KEY``, and provide them to end users.
+``JWT_SECRET_KEY``, and provide them to end users. 
+The payload must contain :code:`"type": "refresh"` and an :code:`identity` claim 
+(Flask-JWT-extended 
+`deviates <https://github.com/vimalloc/flask-jwt-extended/issues/264#issuecomment-517929886>`__ 
+from the standard :code:`sub` claim).
 
 Authentication
 **************

--- a/app.conf.template
+++ b/app.conf.template
@@ -10,6 +10,11 @@ DOCS_BASE_URL = 'https://servicex.readthedocs.io/en/latest/'
 # Enable JWT auth on public endpoints
 ENABLE_AUTH=False
 
+# Disable built-in ServiceX user management system (OAuth via Globus)
+# If set to True while ENABLE_AUTH is also True, then you must generate your
+# own JWT refresh tokens with identity claims using the JWT_SECRET_KEY
+DISABLE_USER_MGMT = False
+
 # Globus configuration - obtained at https://auth.globus.org/v2/web/developers
 GLOBUS_CLIENT_ID='globus-client-id'
 GLOBUS_CLIENT_SECRET='globus-client-secret'

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -43,14 +43,15 @@ class ServiceXResource(Resource):
     @staticmethod
     def get_requesting_user() -> Optional[UserModel]:
         """
-        :return: User who submitted request for resource.
-        If auth is enabled, this cannot be None for JWT-protected resources
-        which are decorated with @auth_required or @admin_required.
+        :return: ServiceX user who submitted request for resource.
+        Returns None if auth or user management is disabled.
         """
-        user = None
-        if current_app.config.get('ENABLE_AUTH'):
-            user = UserModel.find_by_sub(get_jwt_identity())
-        return user
+        config = current_app.config
+        if not config.get('ENABLE_AUTH') or config.get('DISABLE_USER_MGMT'):
+            return None
+        sub = get_jwt_identity()
+        if sub is not None:
+            return UserModel.find_by_sub(sub)
 
     @classmethod
     def _get_app_version(cls):

--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -39,7 +39,7 @@
         {% endif %}
         </div>
         <!-- Navbar Right Side -->
-        {% if config['ENABLE_AUTH'] %}
+        {% if config['ENABLE_AUTH'] and not config['DISABLE_USER_MGMT'] %}
           <div class="navbar-nav">
           {% if not session['is_authenticated'] %}
             <a href="{{ url_for('sign_in') }}" class="nav-item nav-link">Sign In</a>

--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -34,7 +34,7 @@
       <div class="collapse navbar-collapse" id="navbarToggle">
         <div class="navbar-nav mr-auto">
           <a class="nav-item nav-link" href="{{ config['DOCS_BASE_URL'] }}">Docs</a>
-        {% if not config['ENABLE_AUTH'] %}
+        {% if not config['ENABLE_AUTH'] or config['DISABLE_USER_MGMT'] %}
           <a href="{{ url_for('global-dashboard') }}" class="nav-item nav-link">Dashboard</a>
         {% endif %}
         </div>

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -28,6 +28,7 @@
 
 from unittest.mock import MagicMock
 
+from flask.testing import FlaskClient
 from pytest import fixture
 
 from servicex import create_app
@@ -78,7 +79,7 @@ class ResourceTestBase:
         code_gen_service=MagicMock(CodeGenAdapter),
         lookup_result_processor=MagicMock(LookupResultProcessor),
         docker_repo_adapter=None
-    ):
+    ) -> FlaskClient:
         config = ResourceTestBase._app_config()
         config['TRANSFORMER_MANAGER_ENABLED'] = False
         config['TRANSFORMER_MANAGER_MODE'] = 'external'
@@ -99,7 +100,7 @@ class ResourceTestBase:
         return app.test_client()
 
     @fixture
-    def client(self):
+    def client(self) -> FlaskClient:
         return self._test_client()
 
     @staticmethod

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -145,7 +145,10 @@ class ResourceTestBase:
         mock_user.admin = False
         mock_user.pending = False
         mocker.patch(
-            'servicex.resources.servicex_resource.UserModel.find_by_sub',
+            'servicex.decorators.UserModel.find_by_sub', return_value=mock_user
+        )
+        mocker.patch(
+            'servicex.resources.servicex_resource.ServiceXResource.get_requesting_user',
             return_value=mock_user)
         return mock_user
 

--- a/tests/resources/test_servicex_resource.py
+++ b/tests/resources/test_servicex_resource.py
@@ -27,15 +27,42 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pkg_resources
 
+from pytest import fixture
 
-class TestServiceXResource:
+from servicex.resources.servicex_resource import ServiceXResource
+from tests.resource_test_base import ResourceTestBase
+
+
+class TestServiceXResource(ResourceTestBase):
+    module = ServiceXResource.__module__
+
+    @fixture
+    def mock_user(self, mocker):
+        return mocker.patch(f"{self.module}.UserModel.find_by_sub").return_value
+
     def test_get_app_version_no_servicex_app(self, mocker):
         mock_get_distribution = mocker.patch(
-            "servicex.resources.servicex_resource.pkg_resources.get_distribution",
-            side_effect=pkg_resources.DistributionNotFound(None, None))
+            f"{self.module}.pkg_resources.get_distribution",
+            side_effect=pkg_resources.DistributionNotFound(None, None)
+        )
 
-        from servicex.resources.servicex_resource import ServiceXResource
         version = ServiceXResource._get_app_version()
 
         mock_get_distribution.assert_called_with("servicex_app")
         assert version == 'develop'
+
+    def test_get_requesting_user_no_auth(self, client):
+        with client.application.app_context():
+            assert ServiceXResource.get_requesting_user() is None
+
+    def test_get_requesting_user_with_auth(self, mocker, mock_user):
+        mocker.patch(f"{self.module}.get_jwt_identity").return_value = "abcd"
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
+        with client.application.app_context():
+            assert ServiceXResource.get_requesting_user() == mock_user
+
+    def test_get_requesting_user_no_identity(self, mocker):
+        mocker.patch(f"{self.module}.get_jwt_identity").return_value = None
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
+        with client.application.app_context():
+            assert ServiceXResource.get_requesting_user() is None

--- a/tests/resources/users/test_token_refresh.py
+++ b/tests/resources/users/test_token_refresh.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from flask import Response
+from pytest import fixture
+
+from tests.resource_test_base import ResourceTestBase
+
+
+class TestTokenRefresh(ResourceTestBase):
+    module = 'servicex.resources.users.token_refresh'
+    endpoint = '/token/refresh'
+    fake_token = 'abcd'
+
+    @fixture(autouse=True, scope="class")
+    def unwrap(self):
+        """Remove the @jwt_refresh_token_required decorator."""
+        from servicex.resources.users.token_refresh import TokenRefresh
+        TokenRefresh.post = TokenRefresh.post.__wrapped__
+
+    @fixture
+    def jwt_funcs(self, mocker) -> SimpleNamespace:
+        m = self.module
+        patch = mocker.patch
+        sub = "janedoe@example.com"
+        return SimpleNamespace(
+            get_jwt_identity=patch(f"{m}.get_jwt_identity", return_value=sub),
+            create_access_token=patch(f"{m}.create_access_token", return_value=self.fake_token),
+            get_raw_jwt=patch(f"{m}.get_raw_jwt", return_value={"jti": "1234"}),
+            decode_token=mocker.patch(f"{m}.decode_token")
+        )
+
+    @fixture
+    def mock_user(self, mocker) -> MagicMock:
+        return mocker.patch(f"{self.module}.UserModel.find_by_sub").return_value
+
+    def make_request(self, client):
+        response: Response = client.post(self.endpoint)
+        assert response.status_code == 200
+        assert response.json == {'access_token': self.fake_token}
+
+    def test_post_valid_refresh_token(self, client, jwt_funcs, mock_user):
+        jwt_funcs.decode_token.return_value = jwt_funcs.get_raw_jwt.return_value
+        self.make_request(client)
+
+    def test_post_invalid_refresh_token(self, client, jwt_funcs, mock_user):
+        jwt_funcs.decode_token.return_value = {"jti": "this value will not match"}
+        response: Response = client.post(self.endpoint)
+        assert response.status_code == 401
+        assert response.json == {"message": "Invalid or outdated refresh token"}
+
+    def test_post_user_mgmt_disabled(self, jwt_funcs):
+        client = self._test_client(extra_config={'DISABLE_USER_MGMT': True})
+        self.make_request(client)
+        jwt_funcs.get_jwt_identity.assert_called_once()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -175,6 +175,22 @@ class TestDecorators(WebTestBase):
             assert response.status_code == 200
             assert response.json == data
 
+    def test_auth_decorator_integration_user_mgmt_disabled(self, mocker):
+        cfg = {'ENABLE_AUTH': True, 'DISABLE_USER_MGMT': True}
+        client = self._test_client(extra_config=cfg)
+        fake_transform_id = 123
+        data = {'id': fake_transform_id}
+        mock = mocker.patch('servicex.resources.transformation_request'
+                            '.TransformRequest.return_request').return_value
+        mock.to_json.return_value = data
+        with client.application.app_context():
+            response: Response = client.get(
+                f'servicex/transformation/{fake_transform_id}',
+                headers=self.fake_header()
+            )
+            assert response.status_code == 200
+            assert response.json == data
+
     def test_admin_decorator_integration_auth_disabled(self, mocker, client):
         data = {'users': [{'id': 1234}]}
         mocker.patch('servicex.models.UserModel.return_all', return_value=data)
@@ -229,3 +245,13 @@ class TestDecorators(WebTestBase):
             response: Response = client.get('users')
             assert response.status_code == 401
             assert 'restricted' in response.json['message']
+
+    def test_admin_decorator_integration_user_mgmt_disabled(self, mocker):
+        cfg = {'ENABLE_AUTH': True, 'DISABLE_USER_MGMT': True}
+        client = self._test_client(extra_config=cfg)
+        data = {'users': [{'id': 1234}]}
+        mocker.patch('servicex.models.UserModel.return_all', return_value=data)
+        with client.application.app_context():
+            response: Response = client.get('users', headers=self.fake_header())
+            assert response.status_code == 200
+            assert response.json == data


### PR DESCRIPTION
As discussed in ssl-hep/ServiceX#217 with @bbockelm, clusters / analysis facilities with their own authentication system may wish to  opt-out of the authentication system which is currently built into ServiceX (OAuth via Globus + user table in PSQL database).

This PR facilitates this use case by adding a new config value called `DISABLE_USER_MGMT`. When toggled, the authentication decorators will only check for a valid JWT - they will not check against the database to make sure the user exists, is not pending, is an admin, etc.

If this flag is used, cluster admins must generate JWT refresh tokens using the same `JWT_SECRET_KEY` and provide them to end users in some other way. ServiceX will still expect all API requests to protected endpoints to carry a JWT access token, which is obtained by the Python client in the same fashion as usual using the refresh token.

This flag renders many other config values associated with the user management system irrelevant (those for Slack, Globus, Mailgun, etc.) as well as their related endpoints. It does nothing if `ENABLE_AUTH` is set to False, in which case there is no user management system, internal or external.