### PR TITLE
Add retry for creating exchange

### DIFF
--- a/servicex/rabbit_adaptor.py
+++ b/servicex/rabbit_adaptor.py
@@ -107,8 +107,9 @@ class RabbitAdaptor(object):
                 continue
             # Do not recover on channel errors
             except pika.exceptions.AMQPChannelError as err:
-                current_app.logger.exception("Caught a channel error: {}, stopping...".format(err))
-                break
+                current_app.logger.warning("Caught a channel error: {}, retrying...".format(err))
+                self.reset_closed()
+                continue
             # Recover on all other connection errors
             except pika.exceptions.AMQPConnectionError:
                 current_app.logger.warning("Connection was closed, retrying...")

--- a/tests/test_rabbit_adaptor.py
+++ b/tests/test_rabbit_adaptor.py
@@ -352,7 +352,8 @@ class TestRabbitAdaptor(ResourceTestBase):
             mock_channel = mocker.Mock()
             mock_channel.exchange_declare = mocker.Mock(
                 side_effect=[
-                    pika.exceptions.AMQPChannelError
+                    pika.exceptions.AMQPChannelError,
+                    "ok"
                 ]
             )
 
@@ -364,8 +365,8 @@ class TestRabbitAdaptor(ResourceTestBase):
             rabbit.setup_exchange("exchange1")
             mock_pika.assert_called()
             mock_connection.channel.assert_called()
-            assert mock_channel.exchange_declare.call_count == 1
-            assert mock_pika.call_count == 1  # No retry of connection
+            assert mock_channel.exchange_declare.call_count == 2
+            assert mock_pika.call_count == 2  # Retry on channel error
 
     def test_setup_exchange_connection_error(self, mocker, mock_rabbit_adaptor):
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)


### PR DESCRIPTION
# Problem
The app can sometimes fail with `(404, "NOT_FOUND - no exchange 'transformation_requests' in vhost '/'"), stopping...`

Proposed solution to [ServiceX Issue 229](https://github.com/ssl-hep/ServiceX/issues/229)

# Approach
Upon inspection, it looks like the code for creating an exchange gives up if there is a network error. Changed this to close connections and try again like we do for queues. Added unit tests to verify the behavior.