### PR TITLE
Bound version of Flask-JWT-Extended for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'email-validator',
         'pika',
         'flask-restful',
-        'flask-jwt-extended',
+        'flask-jwt-extended>=3.0, <4.0',
         'passlib',
         'flask-sqlalchemy',
         'Flask-Migrate',


### PR DESCRIPTION
A new major version of [Flask-JWT-Extended](https://pypi.org/project/Flask-JWT-Extended), 4.x.x, was recently released with a number of breaking changes. As a result, broken imports are causing test failures (interrupting our CI pipeline and preventing the Docker publish action from succeeding).

While there is an [upgrade guide](https://flask-jwt-extended.readthedocs.io/en/stable/v4_upgrade_guide/) available, this is a stopgap to pin our requirement to version 3.x.x for now.