### PR TITLE
Make HPA min replicas and max replicas configurable

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -48,6 +48,10 @@ TRANSFORMER_MANAGER_ENABLED = True
 # start the requested number of transformers
 TRANSFORMER_AUTOSCALE_ENABLED = True
 
+# Set min and max replicas for autoscaler
+TRANSFORMER_MIN_REPLICAS = 1
+TRANSFORMER_MAX_REPLICAS = 20
+
 # Use one core per transformer
 TRANSFORMER_CPU_LIMIT = 1
 

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -168,6 +168,7 @@ class TransformerManager:
         spec = client.V1HorizontalPodAutoscalerSpec(
             scale_target_ref=target,
             target_cpu_utilization_percentage=cfg["TRANSFORMER_CPU_SCALE_THRESHOLD"],
+            min_replicas=cfg["TRANSFORMER_MIN_REPLICAS"],
             max_replicas=cfg["TRANSFORMER_MAX_REPLICAS"]
         )
         hpa = client.V1HorizontalPodAutoscaler(

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -49,6 +49,7 @@ class ResourceTestBase:
             'TRANSFORMER_NAMESPACE': "my-ws",
             'TRANSFORMER_MANAGER_ENABLED': False,
             'TRANSFORMER_AUTOSCALE_ENABLED': True,
+            'TRANSFORMER_MIN_REPLICAS': 1,
             'TRANSFORMER_MAX_REPLICAS': 5,
             'ADVERTISED_HOSTNAME': 'cern.analysis.ch:5000',
             'TRANSFORMER_PULL_POLICY': 'Always',

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -49,6 +49,7 @@ class ResourceTestBase:
             'TRANSFORMER_NAMESPACE': "my-ws",
             'TRANSFORMER_MANAGER_ENABLED': False,
             'TRANSFORMER_AUTOSCALE_ENABLED': True,
+            'TRANSFORMER_MAX_REPLICAS': 5,
             'ADVERTISED_HOSTNAME': 'cern.analysis.ch:5000',
             'TRANSFORMER_PULL_POLICY': 'Always',
             'TRANSFORMER_VALIDATE_DOCKER_IMAGE': True,

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -113,7 +113,6 @@ class TestTransformerManager(ResourceTestBase):
             assert mock_kubernetes.mock_calls[1][2]['namespace'] == 'my-ns'
             mock_autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_called()
             autoscaling_spec = mock_autoscaling.mock_calls[0][2]['body'].spec
-            print(autoscaling_spec)
             assert autoscaling_spec.max_replicas == 17
             assert autoscaling_spec.scale_target_ref.name == 'transformer-1234'
             assert autoscaling_spec.target_cpu_utilization_percentage == 30

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -82,6 +82,7 @@ class TestTransformerManager(ResourceTestBase):
         cfg = {
             'TRANSFORMER_CPU_LIMIT': 4,
             'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
+            'TRANSFORMER_MIN_REPLICAS': 3,
             'TRANSFORMER_MAX_REPLICAS': 17,
         }
         client = self._test_client(transformation_manager=transformer,
@@ -113,6 +114,7 @@ class TestTransformerManager(ResourceTestBase):
             assert mock_kubernetes.mock_calls[1][2]['namespace'] == 'my-ns'
             mock_autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_called()
             autoscaling_spec = mock_autoscaling.mock_calls[0][2]['body'].spec
+            assert autoscaling_spec.min_replicas == 3
             assert autoscaling_spec.max_replicas == 17
             assert autoscaling_spec.scale_target_ref.name == 'transformer-1234'
             assert autoscaling_spec.target_cpu_utilization_percentage == 30


### PR DESCRIPTION
Updates the HPA spec to retrieve min and max replicas from the app config.

As a result, the `workers` parameter is now only used when autoscaling is disabled. This could be made configurable as well, or we can make the autoscaler a hard dependency and deprecate/remove `workers` in the future.

Note: Technically, this branches off #76, otherwise most of the test suite would fail.