### PR TITLE
Add flake8 pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 .cache
 .pytest_cache/
 .vscode/settings.json
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
             'coverage>=5.2',
             'codecov==2.1.8',
             'pytest-mock==3.2.0',
-            'flake8>=3.8'
+            'flake8>=3.8',
+            'pre-commit'
         ],
     },
 )


### PR DESCRIPTION
Sometimes the CI/CD pipeline fails because of linting issues, slowing down the development cycle. This PR adds the [pre-commit](https://pre-commit.com/) git hook framework as an optional dependency and configures a flake8 pre-commit hook, so that there is immediate feedback during development.

Note: pre-commit hooks must be installed manually after pre-commit is installed. Developers should run:
```
pip install .[test]
pre-commit install
```
It seems [possible](https://blog.kdheepak.com/using-pre-commit-hooks.html) to have the setup script install the hooks automatically, but this works for now.