### PR TITLE
Cleanup of code gen configmap

### DIFF
--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -227,6 +227,11 @@ class TransformerManager:
             namespace=namespace
         )
 
+        api_v1 = client.CoreV1Api()
+        configmap_name = "{}-generated-source".format(request_id)
+        api_v1.delete_namespaced_config_map(name=configmap_name,
+                                            namespace=namespace)
+
     @staticmethod
     def create_configmap_from_zip(zipfile, request_id, namespace):
         configmap_name = "{}-generated-source".format(request_id)

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -227,10 +227,10 @@ class TransformerManager:
             namespace=namespace
         )
 
-        api_v1 = client.CoreV1Api()
+        api_core = client.CoreV1Api()
         configmap_name = "{}-generated-source".format(request_id)
-        api_v1.delete_namespaced_config_map(name=configmap_name,
-                                            namespace=namespace)
+        api_core.delete_namespaced_config_map(name=configmap_name,
+                                              namespace=namespace)
 
     @staticmethod
     def create_configmap_from_zip(zipfile, request_id, namespace):

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -279,9 +279,14 @@ class TestTransformerManager(ResourceTestBase):
         import kubernetes
 
         mocker.patch.object(kubernetes.config, 'load_kube_config')
+
         mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
         mocker.patch.object(kubernetes.client, 'AppsV1Api',
                             return_value=mock_api)
+
+        mock_core_api = mocker.MagicMock(kubernetes.client.CoreV1Api)
+        mocker.patch.object(kubernetes.client, 'CoreV1Api',
+                            return_value=mock_core_api)
 
         mock_autoscaling = mocker.Mock()
         mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
@@ -294,7 +299,10 @@ class TestTransformerManager(ResourceTestBase):
             transformer.shutdown_transformer_job('1234', 'my-ns')
             mock_api.delete_namespaced_deployment.assert_called_with(name='transformer-1234',
                                                                      namespace='my-ns')
-
+            mock_core_api.delete_namespaced_config_map.assert_called_with(
+                name='1234-generated-source',
+                namespace='my-ns'
+            )
             mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.assert_called_with(
                 name='transformer-1234',
                 namespace='my-ns')
@@ -303,9 +311,14 @@ class TestTransformerManager(ResourceTestBase):
         import kubernetes
 
         mocker.patch.object(kubernetes.config, 'load_kube_config')
+
         mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
         mocker.patch.object(kubernetes.client, 'AppsV1Api',
                             return_value=mock_api)
+
+        mock_core_api = mocker.MagicMock(kubernetes.client.CoreV1Api)
+        mocker.patch.object(kubernetes.client, 'CoreV1Api',
+                            return_value=mock_core_api)
 
         mock_autoscaling = mocker.Mock()
         mocker.patch.object(kubernetes.client, 'AutoscalingV1Api', return_value=mock_autoscaling)
@@ -319,7 +332,10 @@ class TestTransformerManager(ResourceTestBase):
             transformer.shutdown_transformer_job('1234', 'my-ns')
             mock_api.delete_namespaced_deployment.assert_called_with(name='transformer-1234',
                                                                      namespace='my-ns')
-
+            mock_core_api.delete_namespaced_config_map.assert_called_with(
+                name='1234-generated-source',
+                namespace='my-ns'
+            )
             mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.assert_not_called()
 
     def test_create_configmap_from_zip(self, mocker):


### PR DESCRIPTION
currently we have hundreds of these config maps undelete in river. 