### PR TITLE
adding export to the transformer

### DIFF
--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -86,14 +86,14 @@ class TransformerManager:
                 field_path="metadata.name"))
         env_var_pod_name = client.V1EnvVar("POD_NAME", value_from=pod_name_value_from)
 
-        # Provide each pod with and environment var holding that instance name
-        instance_name_value_from = client.V1EnvVarSource(
-            field_ref=client.V1ObjectFieldSelector(
-                field_path="metadata.labels['instance_name']"))
-        env_var_instance_name = client.V1EnvVar("INSTANCE_NAME",
-                                                value_from=instance_name_value_from)
+        env = env + [env_var_pod_name]
 
-        env = env + [env_var_pod_name, env_var_instance_name]
+        # Provide each pod with an environment var holding that instance name
+        if "INSTANCE_NAME" in current_app.config:
+            instance_name = current_app.config['INSTANCE_NAME']
+            env_var_instance_name = client.V1EnvVar("INSTANCE_NAME",
+                                                    value=instance_name)
+            env = env + [env_var_instance_name]
 
         if result_destination == 'object-store':
             env = env + [

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -86,7 +86,14 @@ class TransformerManager:
                 field_path="metadata.name"))
         env_var_pod_name = client.V1EnvVar("POD_NAME", value_from=pod_name_value_from)
 
-        env = env + [env_var_pod_name]
+        # Provide each pod with and environment var holding that instance name
+        instance_name_value_from = client.V1EnvVarSource(
+            field_ref=client.V1ObjectFieldSelector(
+                field_path="metadata.labels['instance_name']"))
+        env_var_instance_name = client.V1EnvVar("INSTANCE_NAME",
+                                                value_from=instance_name_value_from)
+
+        env = env + [env_var_pod_name, env_var_instance_name]
 
         if result_destination == 'object-store':
             env = env + [


### PR DESCRIPTION
this gives transformer pods access to the name of servicex instance that spawned them. This is one to the things we want in the log lines.