### PR TITLE
Add transformer deployment status endpoint

### DIFF
--- a/servicex/resources/deployment_status.py
+++ b/servicex/resources/deployment_status.py
@@ -1,0 +1,18 @@
+from flask import jsonify
+
+from servicex.decorators import auth_required
+from servicex.resources.servicex_resource import ServiceXResource
+from servicex.resources.transform_start import TransformStart
+from servicex.transformer_manager import TransformerManager
+
+
+class DeploymentStatus(ServiceXResource):
+    @auth_required
+    def get(self, request_id):
+        # todo - improve dependency injection
+        manager: TransformerManager = TransformStart.transformer_manager
+        status = manager.get_deployment_status(request_id)
+        if status is None:
+            msg = f"Deployment not found for request with id: '{request_id}'"
+            return {'message': msg}, 404
+        return jsonify(status.to_dict())

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -44,6 +44,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.resources.transformer_file_complete import TransformerFileComplete
     from servicex.resources.transform_errors import TransformErrors
     from servicex.resources.info import Info
+    from servicex.resources.deployment_status import DeploymentStatus
 
     from servicex.resources.users.all_users import AllUsers
     from servicex.resources.users.token_refresh import TokenRefresh
@@ -87,17 +88,14 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
 
     # Client public endpoints
     api.add_resource(Info, '/servicex')
-    api.add_resource(SubmitTransformationRequest, '/servicex/transformation')
-
-    api.add_resource(AllTransformationRequests, '/servicex/transformation')
-    api.add_resource(TransformationRequest,
-                     '/servicex/transformation/<string:request_id>')
-
-    api.add_resource(TransformationStatus,
-                     '/servicex/transformation/<string:request_id>/status')
-
-    api.add_resource(TransformErrors,
-                     '/servicex/transformation/<string:request_id>/errors')
+    prefix = "/servicex/transformation"
+    api.add_resource(SubmitTransformationRequest, prefix)
+    api.add_resource(AllTransformationRequests, prefix)
+    prefix += "/<string:request_id>"
+    api.add_resource(TransformationRequest, prefix)
+    api.add_resource(TransformationStatus, prefix + "/status")
+    api.add_resource(TransformErrors, prefix + "/errors")
+    api.add_resource(DeploymentStatus, prefix + "/deployment-status")
 
     # Internal service endpoints
     api.add_resource(TransformationStatusInternal,

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -242,8 +242,8 @@ class TransformerManager:
 
     @staticmethod
     def get_deployment_status(
-            request_id: str
-    ) -> Optional[kubernetes.client.AppsV1beta1DeploymentStatus]:
+        request_id: str
+    ) -> Optional[kubernetes.client.models.v1_deployment_status.V1DeploymentStatus]:
         namespace = current_app.config["TRANSFORMER_NAMESPACE"]
         api = client.AppsV1Api()
         selector = f"metadata.name=transformer-{request_id}"

--- a/tests/resources/test_deployment_status.py
+++ b/tests/resources/test_deployment_status.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+from pytest import fixture
+
+from tests.resource_test_base import ResourceTestBase
+
+
+class TestDeploymentStatus(ResourceTestBase):
+    @fixture
+    def mock_deployment_status(self) -> MagicMock:
+        mock_deployment_status = MagicMock()
+        mock_deployment_status.to_dict.return_value = {
+            "available_replicas": 1,
+            "collision_count": None,
+            "observed_generation": 19,
+            "ready_replicas": 1,
+            "replicas": 1,
+            "unavailable_replicas": None,
+            "updated_replicas": 1,
+        }
+        return mock_deployment_status
+
+    def test_deployment_status(
+            self, mocker, mock_rabbit_adaptor, mock_deployment_status
+    ):
+        mock_transform_start = mocker.MagicMock()
+        mock_transformer_mgr = mock_transform_start.transformer_manager
+        mock_transformer_mgr.get_deployment_status.return_value = mock_deployment_status
+        mocker.patch(
+            'servicex.resources.deployment_status.TransformStart', mock_transform_start
+        )
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        response = client.get("/servicex/transformation/1234/deployment-status")
+        assert response.status_code == 200
+        assert response.json == mock_deployment_status.to_dict.return_value
+
+    def test_deployment_status_404(self, mocker, mock_rabbit_adaptor):
+        mock_transform_start = mocker.MagicMock()
+        mock_transformer_mgr = mock_transform_start.transformer_manager
+        mock_transformer_mgr.get_deployment_status.return_value = None
+        mocker.patch(
+            'servicex.resources.deployment_status.TransformStart', mock_transform_start
+        )
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        response = client.get("/servicex/transformation/1234/deployment-status")
+        assert response.status_code == 404


### PR DESCRIPTION
Breaking up #79 into multiple PRs. This PR simply adds a new endpoint at `/servicex/transformation/<request-id>/deployment-status` which returns a JSONified Kubernetes [DeploymentStatus](https://github.com/kubernetes-client/python/blob/6d64cf67d38337a6fdde1908bdadf047b7118731/kubernetes/docs/V1DeploymentStatus.md) object, or 404 if no deployment is found matching the given `<request-id>`.

Note: Dependency injection for the transformer manager is implemented via borrowing it from the `TransformStart` resource class:
```python
manager: TransformerManager = TransformStart.transformer_manager
```
This is less than ideal, but a more elegant approach to dependency injection is out of scope for this PR - see #91.