### PR TITLE
Skip alembic migrations for sqllite

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 mkdir instance
-FLASK_APP=servicex/app.py flask db upgrade
-#flask db upgrade
-#flask translate compile
+# SQLite doesn't handle migrations, so rely on SQLAlchmy table creation
+if grep "sqlite:////sqlite/app.db" /opt/servicex/app.conf; then
+  echo "SQLLite DB, so skipping db migrations";
+else
+  FLASK_APP=servicex/app.py flask db upgrade;
+fi
+
 exec gunicorn -b :5000 --workers=5 --threads=1 --timeout 120 --access-logfile - --error-logfile - "servicex:create_app()"

--- a/boot.sh
+++ b/boot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 mkdir instance
 # SQLite doesn't handle migrations, so rely on SQLAlchmy table creation
-if grep "sqlite:////sqlite/app.db" /opt/servicex/app.conf; then
+if grep "sqlite://" /opt/servicex/app.conf; then
   echo "SQLLite DB, so skipping db migrations";
 else
   FLASK_APP=servicex/app.py flask db upgrade;


### PR DESCRIPTION
# Problem
SQLite doesn't support many database schema changes, so deploying the app against this sort of db fails.

# Approach
The SQLAlchemy library is happy to create a fresh db when the app if first launched against a blank db. Added a conditional to `boot.sh` to see if we are using sqlite and if so, skipping the migration step.

The test looks in the app config file to find out the database url