### PR TITLE
Allow access to protected API endpoints from web sessions

### DIFF
--- a/servicex/decorators.py
+++ b/servicex/decorators.py
@@ -34,6 +34,7 @@ def auth_required(fn: Callable[..., Response]) -> Callable[..., Response]:
     Pending or deleted users will receive a 401: Unauthorized response.
     """
 
+    @wraps(fn)
     def inner(*args, **kwargs) -> Response:
         if not current_app.config.get('ENABLE_AUTH'):
             return fn(*args, **kwargs)
@@ -62,6 +63,7 @@ def auth_required(fn: Callable[..., Response]) -> Callable[..., Response]:
 def admin_required(fn: Callable[..., Response]) -> Callable[..., Response]:
     """Mark an API resource as requiring administrator role."""
 
+    @wraps(fn)
     def inner(*args, **kwargs) -> Response:
         if not current_app.config.get('ENABLE_AUTH'):
             return fn(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from pytest import fixture
+
+
+@fixture
+def mock_jwt_extended(mocker):
+    """
+    During unit tests, functions from Flask-JWT-extended are mocked to do nothing.
+    """
+    mocker.patch('servicex.decorators.verify_jwt_in_request')

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -124,12 +124,6 @@ class ResourceTestBase:
         return docker
 
     @fixture
-    def mock_jwt_required(self, mocker):
-        def identity(fn):
-            return fn
-        mocker.patch('servicex.decorators.jwt_required', side_effect=identity)
-
-    @fixture
     def mock_requesting_user(self, mocker):
         test_id = 6
         mock_user = mocker.Mock()

--- a/tests/resources/test_all_transformation_requests.py
+++ b/tests/resources/test_all_transformation_requests.py
@@ -52,7 +52,7 @@ class TestAllTransformationRequest(ResourceTestBase):
         assert response.json == self.example_json()
         mock_return_json.assert_called()
 
-    def test_get_all_auth_enabled(self, mock_rabbit_adaptor, mock_jwt_required,
+    def test_get_all_auth_enabled(self, mock_rabbit_adaptor, mock_jwt_extended,
                                   mock_return_json, mock_requesting_user):
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
                                    extra_config={'ENABLE_AUTH': True})
@@ -61,7 +61,7 @@ class TestAllTransformationRequest(ResourceTestBase):
         assert response.json == self.example_json()
         mock_return_json.assert_called()
 
-    def test_get_by_user(self, mock_rabbit_adaptor, mock_jwt_required,
+    def test_get_by_user(self, mock_rabbit_adaptor, mock_jwt_extended,
                          mock_requesting_user, mock_return_json):
         user_id = mock_requesting_user.id
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,

--- a/tests/resources/test_submit_transformation_request.py
+++ b/tests/resources/test_submit_transformation_request.py
@@ -382,7 +382,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
     def test_submit_transformation_auth_enabled(self, mock_rabbit_adaptor,
                                                 mock_docker_repo_adapter,
-                                                mock_jwt_required,
+                                                mock_jwt_extended,
                                                 mock_requesting_user):
         client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
                                    docker_repo_adapter=mock_docker_repo_adapter,


### PR DESCRIPTION
Currently, one cannot access protected API endpoints from the web frontend, even after signing in with OAuth. An easy test for this is to sign in and then attempt to access the `/servicex/transformation` route (which would normally return all transformation requests in the database as a JSON list).

This is because the current implementation of the `auth_required` decorator checks for a JWT access token in the bearer token HTTP header, but the web frontend uses session-based authentication, not token-based authentication.

This PR addresses the issue by checking the `is_authenticated` flag in the current `session` object first, before looking for a bearer token in the request. This allows the web frontend to access protected endpoints, so we can now use AJAX to display API data on the website.