### PR TITLE
Rework model classes

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -210,20 +210,20 @@ class TransformRequest(db.Model):
             return None
 
     @property
-    def submitter_name(self):
-        if self.submitted_by is None:
-            return None
-        elif self.user is None:
-            return "[deleted]"
-        return self.user.name
-
-    @property
     def age(self) -> timedelta:
         return datetime.utcnow() - self.submit_time
 
     @property
     def incomplete(self) -> bool:
         return self.status not in {"Complete", "Fatal"}
+
+    @property
+    def submitter_name(self):
+        if self.submitted_by is None:
+            return None
+        elif self.user is None:
+            return "[deleted]"
+        return self.user.name
 
     @property
     def result_count(self) -> int:

--- a/servicex/resources/servicex_resource.py
+++ b/servicex/resources/servicex_resource.py
@@ -25,7 +25,6 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from datetime import datetime, timezone
 from typing import Optional
 
 import pkg_resources
@@ -33,7 +32,7 @@ from flask import current_app
 from flask_jwt_extended import get_jwt_identity
 from flask_restful import Resource
 
-from servicex.models import TransformationResult, UserModel
+from servicex.models import UserModel
 
 
 class ServiceXResource(Resource):
@@ -52,49 +51,6 @@ class ServiceXResource(Resource):
         if current_app.config.get('ENABLE_AUTH'):
             user = UserModel.find_by_sub(get_jwt_identity())
         return user
-
-    @staticmethod
-    def _generate_file_status_record(dataset_file, status):
-        time = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
-
-        return {
-            "req_id": dataset_file.request_id,
-            "adler32": dataset_file.adler32,
-            "file_size": dataset_file.file_size,
-            "file_events": dataset_file.file_events,
-            "file_path": dataset_file.file_path,
-            "status": status,
-            "info": 'info',
-            "created_at": time,
-            "last_accessed_at": time,
-            "events_served": 0,
-            "retries": 0
-        }
-
-    def _generate_transformation_record(self, submitted_request, status):
-        request_id = submitted_request.request_id
-        count = TransformationResult.count(request_id)
-        time = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
-        current_stats = TransformationResult.statistics(request_id)
-
-        events_transformed = 0 if not current_stats else current_stats['total-events']
-        return {
-            "name": 'Transformation Request',
-            "description": 'Transformation Request',
-            "dataset": submitted_request.did,
-            "dataset_size": int(submitted_request.total_bytes or 0),
-            "dataset_files": count,
-            "dataset_events": int(submitted_request.total_events or 0),
-            "columns": submitted_request.columns,
-            "events": 0,
-            "events_transformed": events_transformed,
-            "events_served": 0,
-            "events_processed": 0,
-            "created_at": submitted_request.submit_time,
-            "modified_at": time,
-            "status": status,
-            "info": ' '
-        }
 
     @classmethod
     def _get_app_version(cls):

--- a/servicex/resources/transform_status.py
+++ b/servicex/resources/transform_status.py
@@ -48,23 +48,19 @@ class TransformationStatus(ServiceXResource):
 
         status_request = status_request_parser.parse_args()
 
-        count = TransformationResult.count(request_id)
-        stats = TransformationResult.statistics(request_id)
-        failures = TransformationResult.failed_files(request_id)
-        print(count, stats)
-        print(TransformRequest.files_remaining(request_id))
         result_dict = {
             "status": transform.status,
             "request-id": request_id,
-            "files-processed": count - failures,
-            "files-skipped": failures,
-            "files-remaining": TransformRequest.files_remaining(request_id),
-            "stats": stats
+            "files-processed": transform.files_processed,
+            "files-skipped": transform.files_failed,
+            "files-remaining": transform.files_remaining,
+            "stats": transform.statistics
         }
 
         if status_request.details:
             result_dict['details'] = TransformationResult.to_json_list(
-                TransformationResult.get_all_status(request_id))
+                transform.results
+            )
 
         return jsonify(result_dict)
 

--- a/servicex/resources/transformer_file_complete.py
+++ b/servicex/resources/transformer_file_complete.py
@@ -40,6 +40,9 @@ class TransformerFileComplete(ServiceXResource):
     def put(self, request_id):
         info = request.get_json()
         submitted_request = TransformRequest.return_request(request_id)
+        if submitted_request is None:
+            return {"message": f"Request not found with id: '{request_id}'"}, 404
+
         dataset_file = DatasetFile.get_by_id(info['file-id'])
 
         rec = TransformationResult(
@@ -56,8 +59,7 @@ class TransformerFileComplete(ServiceXResource):
         )
         rec.save_to_db()
 
-        files_remaining = TransformRequest.files_remaining(request_id)
-        if files_remaining is not None and files_remaining <= 0:
+        if submitted_request.files_remaining <= 0:
             namespace = current_app.config['TRANSFORMER_NAMESPACE']
             print("Job is all done... shutting down transformers")
             self.transformer_manager.shutdown_transformer_job(request_id, namespace)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,17 @@ from servicex.models import UserModel, TransformRequest
 
 class TestTransformRequest:
 
+    def test_incomplete(self):
+        for status, expected in [
+            ("Submitted", True),
+            ("Running", True),
+            ("Complete", False),
+            ("Fatal", False)
+        ]:
+            request = TransformRequest()
+            request.status = status
+            assert request.incomplete == expected
+
     def test_submitter_name(self):
         user = UserModel()
         user.id = 1234

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,15 @@
+from servicex.models import TransformRequest
+
+
+class TestTransformRequest:
+
+    def test_files_remaining(self, mocker):
+        request = TransformRequest()
+        request.files = 17
+        TransformRequest.result_count = mocker.PropertyMock(return_value=10)
+        assert request.files_remaining == 7
+
+    def test_files_remaining_unknown(self, mocker):
+        request = TransformRequest()
+        request.files = None
+        assert request.files_remaining is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,29 @@
-from servicex.models import TransformRequest
+from servicex.models import UserModel, TransformRequest
 
 
 class TestTransformRequest:
+
+    def test_submitter_name(self):
+        user = UserModel()
+        user.id = 1234
+        user.name = "Leonardo"
+        request = TransformRequest()
+        request.submitted_by = user.id
+        request.user = user
+        assert request.submitter_name == user.name
+
+    def test_submitted_name_deleted(self):
+        user = UserModel()
+        user.id = 1234
+        user.name = "Leonardo"
+        request = TransformRequest()
+        request.submitted_by = user.id
+        request.user = None
+        assert request.submitter_name == "[deleted]"
+
+    def test_submitted_name_none(self):
+        request = TransformRequest()
+        assert request.submitter_name is None
 
     def test_files_remaining(self, mocker):
         request = TransformRequest()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,19 @@
+from datetime import datetime, timedelta
+
 from servicex.models import UserModel, TransformRequest
 
 
 class TestTransformRequest:
+
+    def test_age(self, mocker):
+        request = TransformRequest()
+        t = datetime(2021, 1, 1)
+        delta = timedelta(days=1, hours=3, minutes=5)
+        request.submit_time = t
+        mock_dt = mocker.patch("servicex.models.datetime")
+        mock_dt.utcnow.return_value = t+delta
+        assert request.age == delta
+        assert mock_dt.utcnow.called_once()
 
     def test_incomplete(self):
         for status, expected in [


### PR DESCRIPTION
This PR contains enhancements and refactoring of the `TransformRequest` and `TransformationResult` model classes.

Changes include the following:
- Three new properties on `TransformRequest`: `incomplete` (boolean), `age` (timedelta), and `submitter_name` (nullable string).
- Various class methods of `TransformationResult` intended to compute the number of files remaining/completed/total and other statistics for a given transformation request have been moved to properties of the `TransformRequest` class.
- Affected endpoints have been updated, and tests have been refactored. Properties are mocked in the recommended fashion using [`unittest.mock.PropertyMock`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock).