### PR TITLE
Reduce boilerplate in unit tests

### DIFF
--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -73,10 +73,10 @@ class ResourceTestBase:
     def _test_client(
         extra_config=None,
         transformation_manager=None,
-        rabbit_adaptor=None,
+        rabbit_adaptor=MagicMock(RabbitAdaptor),
         object_store=None,
-        code_gen_service=None,
-        lookup_result_processor=None,
+        code_gen_service=MagicMock(CodeGenAdapter),
+        lookup_result_processor=MagicMock(LookupResultProcessor),
         docker_repo_adapter=None
     ):
         config = ResourceTestBase._app_config()
@@ -85,17 +85,8 @@ class ResourceTestBase:
         config['DID_FINDER_DEFAULT_SCHEME'] = 'rucio'
         config['VALID_DID_SCHEMES'] = ['rucio']
 
-        if extra_config:
+        if extra_config is not None:
             config.update(extra_config)
-
-        if rabbit_adaptor is None:
-            rabbit_adaptor = MagicMock(RabbitAdaptor)
-
-        if code_gen_service is None:
-            code_gen_service = MagicMock(CodeGenAdapter)
-
-        if lookup_result_processor is None:
-            lookup_result_processor = MagicMock(LookupResultProcessor)
 
         if docker_repo_adapter is None:
             docker_repo_adapter = MagicMock(DockerRepoAdapter)

--- a/tests/resources/test_add_file_to_dataset.py
+++ b/tests/resources/test_add_file_to_dataset.py
@@ -34,7 +34,7 @@ def set_dataset_file_id(submitted_request, dataset_file):
 
 
 class TestAddFileToDataset(ResourceTestBase):
-    def test_put_new_file(self, mocker,  mock_rabbit_adaptor):
+    def test_put_new_file(self, mocker):
         import servicex
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
@@ -42,11 +42,9 @@ class TestAddFileToDataset(ResourceTestBase):
             return_value=self._generate_transform_request())
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
-        mock_processor.add_file_to_dataset = mocker.Mock(side_effect=set_dataset_file_id)
+        mock_processor.add_file_to_dataset.side_effect = set_dataset_file_id
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   lookup_result_processor=mock_processor
-                                   )
+        client = self._test_client(lookup_result_processor=mock_processor)
 
         response = client.put('/servicex/internal/transformation/1234/files',
                               json={
@@ -63,7 +61,7 @@ class TestAddFileToDataset(ResourceTestBase):
             "file-id": '42'
         }
 
-    def test_put_new_file_root_dest(self, mocker,  mock_rabbit_adaptor):
+    def test_put_new_file_root_dest(self, mocker):
         import servicex
 
         root_file_transform_request = self._generate_transform_request()
@@ -76,10 +74,9 @@ class TestAddFileToDataset(ResourceTestBase):
             return_value=root_file_transform_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
-        mock_processor.add_file_to_dataset = mocker.Mock(side_effect=set_dataset_file_id)
+        mock_processor.add_file_to_dataset.side_effect = set_dataset_file_id
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   lookup_result_processor=mock_processor)
+        client = self._test_client(lookup_result_processor=mock_processor)
         response = client.put('/servicex/internal/transformation/1234/files',
                               json={
                                   'file_path': '/foo/bar.root',
@@ -96,7 +93,7 @@ class TestAddFileToDataset(ResourceTestBase):
             "file-id": "42"
         }
 
-    def test_put_new_file_with_exception(self, mocker, mock_rabbit_adaptor):
+    def test_put_new_file_with_exception(self, mocker):
         import servicex
         mocker.patch.object(
             servicex.models.TransformRequest,
@@ -104,10 +101,9 @@ class TestAddFileToDataset(ResourceTestBase):
             return_value=self._generate_transform_request())
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
-        mock_processor.add_file_to_dataset = mocker.Mock(side_effect=Exception('Test'))
+        mock_processor.add_file_to_dataset.side_effect = Exception('Test')
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   lookup_result_processor=mock_processor)
+        client = self._test_client(lookup_result_processor=mock_processor)
 
         response = client.put('/servicex/internal/transformation/1234/files',
                               json={

--- a/tests/resources/test_all_transformation_requests.py
+++ b/tests/resources/test_all_transformation_requests.py
@@ -44,28 +44,26 @@ class TestAllTransformationRequest(ResourceTestBase):
             return_value=self.example_json())
         return mock_return_json
 
-    def test_get_all_auth_disabled(self, mock_rabbit_adaptor,
-                                   mock_return_json):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_get_all_auth_disabled(self, client, mock_return_json):
         response: Response = client.get('/servicex/transformation')
         assert response.status_code == 200
         assert response.json == self.example_json()
         mock_return_json.assert_called()
 
-    def test_get_all_auth_enabled(self, mock_rabbit_adaptor, mock_jwt_extended,
-                                  mock_return_json, mock_requesting_user):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   extra_config={'ENABLE_AUTH': True})
+    def test_get_all_auth_enabled(
+        self, mock_jwt_extended, mock_return_json, mock_requesting_user
+    ):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         response: Response = client.get('/servicex/transformation')
         assert response.status_code == 200
         assert response.json == self.example_json()
         mock_return_json.assert_called()
 
-    def test_get_by_user(self, mock_rabbit_adaptor, mock_jwt_extended,
-                         mock_requesting_user, mock_return_json):
+    def test_get_by_user(
+        self, mock_jwt_extended, mock_requesting_user, mock_return_json
+    ):
         user_id = mock_requesting_user.id
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         response = client.get(f'/servicex/transformation?submitted_by={user_id}')
         assert response.status_code == 200
         assert response.json == self.example_json()

--- a/tests/resources/test_deployment_status.py
+++ b/tests/resources/test_deployment_status.py
@@ -21,7 +21,7 @@ class TestDeploymentStatus(ResourceTestBase):
         return mock_deployment_status
 
     def test_deployment_status(
-            self, mocker, mock_rabbit_adaptor, mock_deployment_status
+            self, mocker, client, mock_deployment_status
     ):
         mock_transform_start = mocker.MagicMock()
         mock_transformer_mgr = mock_transform_start.transformer_manager
@@ -29,18 +29,16 @@ class TestDeploymentStatus(ResourceTestBase):
         mocker.patch(
             'servicex.resources.deployment_status.TransformStart', mock_transform_start
         )
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         response = client.get("/servicex/transformation/1234/deployment-status")
         assert response.status_code == 200
         assert response.json == mock_deployment_status.to_dict.return_value
 
-    def test_deployment_status_404(self, mocker, mock_rabbit_adaptor):
+    def test_deployment_status_404(self, mocker, client):
         mock_transform_start = mocker.MagicMock()
         mock_transformer_mgr = mock_transform_start.transformer_manager
         mock_transformer_mgr.get_deployment_status.return_value = None
         mocker.patch(
             'servicex.resources.deployment_status.TransformStart', mock_transform_start
         )
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         response = client.get("/servicex/transformation/1234/deployment-status")
         assert response.status_code == 404

--- a/tests/resources/test_fileset_complete.py
+++ b/tests/resources/test_fileset_complete.py
@@ -30,7 +30,7 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestFilesetComplete(ResourceTestBase):
-    def test_put_fileset_complete(self, mocker,  mock_rabbit_adaptor):
+    def test_put_fileset_complete(self, mocker):
         import servicex
         submitted_request = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
@@ -40,8 +40,7 @@ class TestFilesetComplete(ResourceTestBase):
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   lookup_result_processor=mock_processor)
+        client = self._test_client(lookup_result_processor=mock_processor)
 
         response = client.put('/servicex/internal/transformation/1234/complete',
                               json={

--- a/tests/resources/test_preflight_check.py
+++ b/tests/resources/test_preflight_check.py
@@ -29,7 +29,7 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestPreflightCheck(ResourceTestBase):
-    def test_post_preflight_check(self, mocker, mock_rabbit_adaptor):
+    def test_post_preflight_check(self, mocker):
         import servicex
         from servicex.lookup_result_processor import LookupResultProcessor
 
@@ -40,11 +40,8 @@ class TestPreflightCheck(ResourceTestBase):
             return_value=submitted_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
-        mock_processor.publish_preflight_request = mocker.Mock()
 
-        client = self._test_client(
-            rabbit_adaptor=mock_rabbit_adaptor,
-            lookup_result_processor=mock_processor)
+        client = self._test_client(lookup_result_processor=mock_processor)
         response = client.post('/servicex/internal/transformation/1234/preflight',
                                json={'file_path': '/foo/bar.root'})
         assert response.status_code == 200
@@ -59,7 +56,7 @@ class TestPreflightCheck(ResourceTestBase):
             "file-id": 42
         }
 
-    def test_preflight_check_with_exception(self, mocker, mock_rabbit_adaptor):
+    def test_preflight_check_with_exception(self, mocker):
         import servicex
         from servicex.lookup_result_processor import LookupResultProcessor
 
@@ -71,10 +68,9 @@ class TestPreflightCheck(ResourceTestBase):
             return_value=submitted_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
-        mock_processor.publish_preflight_request = mocker.Mock(side_effect=Exception('Test'))
+        mock_processor.publish_preflight_request.side_effect = Exception('Test')
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   lookup_result_processor=mock_processor)
+        client = self._test_client(lookup_result_processor=mock_processor)
         response = client.post('/servicex/internal/transformation/1234/preflight',
                                json={'file_path': '/foo/bar.root'})
         assert response.status_code == 500

--- a/tests/resources/test_servicex_info.py
+++ b/tests/resources/test_servicex_info.py
@@ -29,8 +29,7 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestServicexInfo(ResourceTestBase):
-    def test_get_info(self, mock_app_version, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_get_info(self, client, mock_app_version):
         response = client.get('/servicex')
         assert response.status_code == 200
         print(response.json)

--- a/tests/resources/test_transform_errors.py
+++ b/tests/resources/test_transform_errors.py
@@ -30,7 +30,7 @@ from servicex.models import DatasetFile, FileStatus
 
 
 class TestTransformErrors(ResourceTestBase):
-    def test_get_errors(self, mocker, mock_rabbit_adaptor):
+    def test_get_errors(self, mocker, client):
         import servicex
 
         mock_transform_request_read = mocker.patch.object(
@@ -52,8 +52,6 @@ class TestTransformErrors(ResourceTestBase):
             'failures_for_request',
             return_value=file_error_result)
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
-
         response = client.get('/servicex/transformation/1234/errors')
         assert response.status_code == 200
         assert response.json == {'errors': [
@@ -67,15 +65,13 @@ class TestTransformErrors(ResourceTestBase):
         mock_transform_request_read.assert_called_with("1234")
         mock_transform_errors.assert_called_with("1234")
 
-    def test_get_errors_404(self, mocker, mock_rabbit_adaptor):
+    def test_get_errors_404(self, mocker, client):
         import servicex
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
             return_value=None)
-
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
 
         response = client.get('/servicex/transformation/1234/errors')
         assert response.status_code == 404

--- a/tests/resources/test_transform_file_complete.py
+++ b/tests/resources/test_transform_file_complete.py
@@ -43,8 +43,7 @@ class TestTransformFileComplete(ResourceTestBase):
             'avg-rate': 30.2
         }
 
-    def test_put_transform_file_complete_files_remaining(self, mocker,
-                                                         mock_rabbit_adaptor):
+    def test_put_transform_file_complete_files_remaining(self, mocker):
         import servicex
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
@@ -60,16 +59,14 @@ class TestTransformFileComplete(ResourceTestBase):
         mocker.patch.object(TransformationResult, "save_to_db")
         mocker.patch.object(TransformRequest, "save_to_db")
 
-        client = self._test_client(transformation_manager=mock_transformer_manager,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(transformation_manager=mock_transformer_manager)
         response = client.put('/servicex/internal/transformation/1234/file-complete',
                               json=self._generate_file_complete_request())
         assert response.status_code == 200
         mock_transform_request_read.assert_called_with('1234')
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
-    def test_put_transform_file_complete_no_files_remaining(self, mocker,
-                                                            mock_rabbit_adaptor):
+    def test_put_transform_file_complete_no_files_remaining(self, mocker):
         import servicex
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
@@ -85,8 +82,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mocker.patch.object(TransformationResult, "save_to_db")
         mocker.patch.object(TransformRequest, "save_to_db")
 
-        client = self._test_client(transformation_manager=mock_transformer_manager,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(transformation_manager=mock_transformer_manager)
         response = client.put('/servicex/internal/transformation/1234/file-complete',
                               json=self._generate_file_complete_request())
 
@@ -95,9 +91,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job.assert_called_with('1234',
                                                                              'my-ws')
 
-    def test_put_transform_file_complete_unknown_request_id(
-        self, mocker, mock_rabbit_adaptor
-    ):
+    def test_put_transform_file_complete_unknown_request_id(self, mocker):
         import servicex
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
@@ -107,8 +101,7 @@ class TestTransformFileComplete(ResourceTestBase):
             return_value=None
         )
 
-        client = self._test_client(transformation_manager=mock_transformer_manager,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(transformation_manager=mock_transformer_manager)
         response = client.put('/servicex/internal/transformation/1234/file-complete',
                               json=self._generate_file_complete_request())
 
@@ -125,8 +118,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_dataset_file.request_id = 'BR549'
         return mock_dataset_file
 
-    def test_file_transform_complete_files_remain(self, mocker,
-                                                  mock_rabbit_adaptor):
+    def test_file_transform_complete_files_remain(self, mocker):
         import servicex
 
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
@@ -143,8 +135,7 @@ class TestTransformFileComplete(ResourceTestBase):
                             return_value=self._generate_dataset_file())
         mocker.patch.object(TransformationResult, "save_to_db")
 
-        client = self._test_client(transformation_manager=mock_transformer_manager,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(transformation_manager=mock_transformer_manager)
         response = client.put('/servicex/internal/transformation/1234/file-complete',
                               json=self._generate_file_complete_request())
 

--- a/tests/resources/test_transform_status.py
+++ b/tests/resources/test_transform_status.py
@@ -29,9 +29,8 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestTransformStatus(ResourceTestBase):
-    def test_post_status(self, mocker, mock_rabbit_adaptor):
+    def test_post_status(self, mocker, client):
         from servicex.models import TransformRequest
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         mock_request = self._generate_transform_request()
         mock_request.save_to_db = mocker.Mock()
         mocker.patch.object(
@@ -49,9 +48,8 @@ class TestTransformStatus(ResourceTestBase):
         assert response.status_code == 200
         mock_request.save_to_db.assert_not_called()
 
-    def test_post_status_fatal(self, mocker, mock_rabbit_adaptor):
+    def test_post_status_fatal(self, mocker, client):
         from servicex.models import TransformRequest
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         mock_request = self._generate_transform_request()
         mock_request.save_to_db = mocker.Mock()
         mocker.patch.object(
@@ -69,14 +67,12 @@ class TestTransformStatus(ResourceTestBase):
         assert response.status_code == 200
         mock_request.save_to_db.assert_called()
 
-    def test_post_status_bad_data(self, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_post_status_bad_data(self, client):
         response = client.post('/servicex/internal/transformation/1234/status',
                                json={'foo': 'bar'})
-
         assert response.status_code == 400
 
-    def test_get_status(self, mocker, mock_rabbit_adaptor):
+    def test_get_status(self, mocker, client):
         import servicex
 
         mock_files_processed = mocker.PropertyMock(return_value=15)
@@ -99,8 +95,6 @@ class TestTransformStatus(ResourceTestBase):
             'return_request',
             return_value=self._generate_transform_request())
 
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
-
         response = client.get('/servicex/transformation/1234/status')
         assert response.status_code == 200
         assert response.json == {
@@ -118,15 +112,13 @@ class TestTransformStatus(ResourceTestBase):
         }
         mock_transform_request_read.assert_called_with("1234")
 
-    def test_get_status_404(self, mocker, mock_rabbit_adaptor):
+    def test_get_status_404(self, mocker, client):
         import servicex
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
             return_value=None)
-
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
 
         response = client.get('/servicex/transformation/1234/status')
         assert response.status_code == 404

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -3,15 +3,13 @@ from tests.resource_test_base import ResourceTestBase
 
 class TestTransformationRequest(ResourceTestBase):
 
-    def test_get_single_request_no_object_store(self, mocker,
-                                                mock_rabbit_adaptor):
+    def test_get_single_request_no_object_store(self, mocker):
         import servicex
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
             return_value=self._generate_transform_request())
-        client = self._test_client(extra_config={'OBJECT_STORE_ENABLED': False},
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(extra_config={'OBJECT_STORE_ENABLED': False})
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
         assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
@@ -31,7 +29,7 @@ class TestTransformationRequest(ResourceTestBase):
                                  }
         mock_transform_request_read.assert_called_with('1234')
 
-    def test_get_single_request_with_object_store(self, mocker, mock_rabbit_adaptor):
+    def test_get_single_request_with_object_store(self, mocker):
         import servicex
         object_store_transform_request = self._generate_transform_request()
         object_store_transform_request.result_destination = 'object-store'
@@ -48,8 +46,7 @@ class TestTransformationRequest(ResourceTestBase):
             'MINIO_SECRET_KEY': 'leftfoot1'
         }
 
-        client = self._test_client(extra_config=local_config,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(extra_config=local_config)
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
         print(response.json)
@@ -91,8 +88,7 @@ class TestTransformationRequest(ResourceTestBase):
             'MINIO_SECRET_KEY': 'leftfoot1'
         }
 
-        client = self._test_client(extra_config=local_config,
-                                   rabbit_adaptor=mock_rabbit_adaptor)
+        client = self._test_client(extra_config=local_config)
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
         assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
@@ -113,12 +109,11 @@ class TestTransformationRequest(ResourceTestBase):
 
         mock_transform_request_read.assert_called_with('1234')
 
-    def test_get_single_request_404(self, mocker, mock_rabbit_adaptor):
+    def test_get_single_request_404(self, mocker, client):
         import servicex
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest, 'return_request',
             return_value=None)
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 404
         mock_transform_request_read.assert_called_with('1234')

--- a/tests/resources/test_transformer_start.py
+++ b/tests/resources/test_transformer_start.py
@@ -29,7 +29,7 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestTransformationStart(ResourceTestBase):
-    def test_transform_start(self, mocker, mock_rabbit_adaptor):
+    def test_transform_start(self, mocker):
         import servicex
         from servicex.transformer_manager import TransformerManager
         mock_transformer_manager = mocker.MagicMock(TransformerManager)
@@ -47,13 +47,13 @@ class TestTransformationStart(ResourceTestBase):
             'servicex.kafka_topic_manager.KafkaTopicManager',
             return_value=mock_kafka_topic_manager)
 
+        cfg = {
+            'TRANSFORMER_MANAGER_ENABLED': True,
+            'TRANSFORMER_X509_SECRET': 'my-x509-secret'
+        }
         client = self._test_client(
-            {
-                'TRANSFORMER_MANAGER_ENABLED': True,
-                'TRANSFORMER_X509_SECRET': 'my-x509-secret'
-            },
-            mock_transformer_manager,
-            mock_rabbit_adaptor)
+            extra_config=cfg, transformation_manager=mock_transformer_manager
+        )
 
         response = client.post('/servicex/internal/transformation/1234/start',
                                json={

--- a/tests/resources/test_web_app_init.py
+++ b/tests/resources/test_web_app_init.py
@@ -31,11 +31,11 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestWebAppInit(ResourceTestBase):
-    def test_invalid_default_did_finder(self, mocker, mock_rabbit_adaptor):
+    def test_invalid_default_did_finder(self):
         bad_config = {
             'DID_FINDER_DEFAULT_SCHEME': 'cuckoo',
             'VALID_DID_SCHEMES': 'rucio'
         }
 
         with pytest.raises(ValueError):
-            self._test_client(extra_config=bad_config, rabbit_adaptor=mock_rabbit_adaptor)
+            self._test_client(extra_config=bad_config)

--- a/tests/resources/users/test_delete_user.py
+++ b/tests/resources/users/test_delete_user.py
@@ -4,8 +4,7 @@ from tests.web.web_test_base import WebTestBase
 
 
 class TestDeleteUser(WebTestBase):
-    def test_delete_user(self, mocker, user):
-        client = self._test_client(mocker)
+    def test_delete_user(self, mocker, client, user):
         user.id = 7
         resp_json = {'message': f'user {user.id} has been deleted'}
         resp: Response = client.delete(f'users/{user.id}')

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -21,8 +21,8 @@ class TestDecorators(WebTestBase):
             response: Response = decorated()
             assert response.status_code == 200
 
-    def test_oauth_decorator_not_signed_in(self, mocker):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_oauth_decorator_not_signed_in(self):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             from servicex.decorators import oauth_required
             decorated = oauth_required(fake_route)
@@ -30,8 +30,8 @@ class TestDecorators(WebTestBase):
             assert response.status_code == 302
             assert response.location == url_for('sign_in')
 
-    def test_oauth_decorator_not_saved(self, mocker):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_oauth_decorator_not_saved(self):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.session_transaction() as sess:
             sess['is_authenticated'] = True
         response: Response = client.get(url_for('profile'))
@@ -58,16 +58,16 @@ class TestDecorators(WebTestBase):
     def test_auth_decorator_user_deleted(self, mocker, mock_jwt_extended):
         mocker.patch('servicex.decorators.UserModel.find_by_sub',
                      return_value=None)
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             from servicex.decorators import auth_required
             decorated = auth_required(fake_route)
             response: Response = decorated()
             assert response.status_code == 401
 
-    def test_auth_decorator_user_pending(self, mocker, mock_jwt_extended, user):
+    def test_auth_decorator_user_pending(self, mock_jwt_extended, user):
         user.pending = True
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             from servicex.decorators import auth_required
             decorated = auth_required(fake_route)
@@ -75,7 +75,7 @@ class TestDecorators(WebTestBase):
             assert response.status_code == 401
 
     def test_auth_decorator_authorized(self, mocker, mock_jwt_extended, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             from servicex.decorators import auth_required
             decorated = auth_required(fake_route)
@@ -90,7 +90,7 @@ class TestDecorators(WebTestBase):
             assert response.status_code == 200
 
     def test_admin_decorator_unauthorized(self, mocker, mock_jwt_extended, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         user.admin = False
         with client.application.app_context():
             from servicex.decorators import admin_required
@@ -98,8 +98,8 @@ class TestDecorators(WebTestBase):
             response: Response = decorated()
             assert response.status_code == 401
 
-    def test_admin_decorator_authorized(self, mocker, mock_jwt_extended, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_admin_decorator_authorized(self, mock_jwt_extended, user):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         user.admin = True
         with client.application.app_context():
             from servicex.decorators import admin_required
@@ -107,29 +107,28 @@ class TestDecorators(WebTestBase):
             response: Response = decorated()
             assert response.status_code == 200
 
-    def test_auth_decorator_integration_auth_disabled(self, mocker):
+    def test_auth_decorator_integration_auth_disabled(self, mocker, client):
         fake_transform_id = 123
         data = {'id': fake_transform_id}
         mock = mocker.patch('servicex.resources.transformation_request'
                             '.TransformRequest.return_request').return_value
         mock.to_json.return_value = data
-        client = self._test_client(mocker)
         with client.application.app_context():
             response: Response = client.get(f'servicex/transformation/{fake_transform_id}')
             print(response.data)
             assert response.status_code == 200
             assert response.json == data
 
-    def test_auth_decorator_integration_no_header(self, mocker):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_auth_decorator_integration_no_header(self):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             response: Response = client.get('servicex/transformation/123')
             print(response.data)
             assert response.status_code == 401
             assert response.json['message'] == 'Missing Authorization Header'
 
-    def test_auth_decorator_integration_user_deleted(self, mocker):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_auth_decorator_integration_user_deleted(self):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             response: Response = client.get('servicex/transformation/123',
                                             headers=self.fake_header())
@@ -138,7 +137,7 @@ class TestDecorators(WebTestBase):
 
     def test_auth_decorator_integration_user_pending(self, mocker, user):
         user.pending = True
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             response: Response = client.get('servicex/transformation/123',
                                             headers=self.fake_header())
@@ -146,7 +145,7 @@ class TestDecorators(WebTestBase):
             assert 'pending' in response.json['message']
 
     def test_auth_decorator_integration_authorized(self, mocker, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         fake_transform_id = 123
         data = {'id': fake_transform_id}
         mock = mocker.patch('servicex.resources.transformation_request'
@@ -161,7 +160,7 @@ class TestDecorators(WebTestBase):
             assert response.json == data
 
     def test_auth_decorator_integration_oauth(self, mocker, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         fake_transform_id = 123
         data = {'id': fake_transform_id}
         mock = mocker.patch('servicex.resources.transformation_request'
@@ -176,25 +175,24 @@ class TestDecorators(WebTestBase):
             assert response.status_code == 200
             assert response.json == data
 
-    def test_admin_decorator_integration_auth_disabled(self, mocker):
+    def test_admin_decorator_integration_auth_disabled(self, mocker, client):
         data = {'users': [{'id': 1234}]}
         mocker.patch('servicex.models.UserModel.return_all', return_value=data)
-        client = self._test_client(mocker)
         with client.application.app_context():
             response: Response = client.get('users')
             assert response.status_code == 200
             assert response.json == data
 
-    def test_admin_decorator_integration_no_header(self, mocker):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_admin_decorator_integration_no_header(self):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             response: Response = client.get('users')
             assert response.status_code == 401
             assert response.json['message'] == 'Missing Authorization Header'
 
-    def test_admin_decorator_integration_not_authorized(self, mocker, user):
+    def test_admin_decorator_integration_not_authorized(self, user):
         user.admin = False
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             response: Response = client.get('users', headers=self.fake_header())
             assert response.status_code == 401
@@ -204,14 +202,14 @@ class TestDecorators(WebTestBase):
         user.admin = True
         data = {'users': [{'id': 1234}]}
         mocker.patch('servicex.models.UserModel.return_all', return_value=data)
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.application.app_context():
             response: Response = client.get('users', headers=self.fake_header())
             assert response.status_code == 200
             assert response.json == data
 
     def test_admin_decorator_integration_oauth_authorized(self, mocker, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         data = {'users': [{'id': 1234}]}
         mocker.patch('servicex.models.UserModel.return_all', return_value=data)
         with client.session_transaction() as sess:
@@ -222,8 +220,8 @@ class TestDecorators(WebTestBase):
             assert response.status_code == 200
             assert response.json == data
 
-    def test_admin_decorator_integration_oauth_not_authorized(self, mocker, user):
-        client = self._test_client(mocker, extra_config={'ENABLE_AUTH': True})
+    def test_admin_decorator_integration_oauth_not_authorized(self, user):
+        client = self._test_client(extra_config={'ENABLE_AUTH': True})
         with client.session_transaction() as sess:
             sess['is_authenticated'] = True
             sess['admin'] = False

--- a/tests/test_mailgun_adaptor.py
+++ b/tests/test_mailgun_adaptor.py
@@ -5,30 +5,27 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestMailgunAdaptor(ResourceTestBase):
-    def test_noop(self, mocker, mock_rabbit_adaptor):
+    def test_noop(self, mocker, client):
         import requests
         mock_post = mocker.patch.object(requests, "post")
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
         with client.application.app_context():
             mailgun = MailgunAdaptor()
             mailgun.send('janedoe@example.com', 'welcome.html')
             mock_post.assert_not_called()
 
-    def test_init(self, mock_rabbit_adaptor):
+    def test_init(self):
         config = {'MAILGUN_API_KEY': 'key123', 'MAILGUN_DOMAIN': 'example.com'}
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   extra_config=config)
+        client = self._test_client(extra_config=config)
         with client.application.app_context():
             mailgun = MailgunAdaptor()
             assert mailgun.api_key == config['MAILGUN_API_KEY']
             assert mailgun.domain == config['MAILGUN_DOMAIN']
 
-    def test_send(self, mocker, mock_rabbit_adaptor):
+    def test_send(self, mocker):
         import requests
         mock_post = mocker.patch.object(requests, "post")
         config = {'MAILGUN_API_KEY': 'key123', 'MAILGUN_DOMAIN': 'example.com'}
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor,
-                                   extra_config=config)
+        client = self._test_client(extra_config=config)
         with client.application.app_context():
             mailgun = MailgunAdaptor()
             email, template_name = 'janedoe@example.com', 'welcome.html'

--- a/tests/test_rabbit_adaptor.py
+++ b/tests/test_rabbit_adaptor.py
@@ -32,16 +32,14 @@ from tests.resource_test_base import ResourceTestBase
 
 
 class TestRabbitAdaptor(ResourceTestBase):
-    def test_connect(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_connect(self, mocker, client):
         with client.application.app_context():
             mock_pika = mocker.patch('pika.BlockingConnection')
             rabbit = RabbitAdaptor("amqp://test.com")
             rabbit.connect()
             mock_pika.assert_called_with([pika.URLParameters("amqp://test.com")])
 
-    def test_setup_queue(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_queue(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -61,8 +59,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             rabbit.setup_queue("my_queue")
             mock_connection.channel.assert_not_called()
 
-    def test_setup_queue_broker_closed(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_queue_broker_closed(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -74,8 +71,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             rabbit = RabbitAdaptor("amqp://test.com")
             rabbit.setup_queue("my_queue")
 
-    def test_setup_queue_wrong_state(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_queue_wrong_state(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -94,8 +90,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             mock_connection.channel.assert_called()
             assert mock_pika.call_count == 2  # Retried the connection
 
-    def test_setup_queue_connection_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_queue_connection_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -114,8 +109,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             mock_connection.channel.assert_called()
             assert mock_pika.call_count == 2  # Retried the connection
 
-    def test_bind_queue_to_exchange(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_bind_queue_to_exchange(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -133,8 +127,7 @@ class TestRabbitAdaptor(ResourceTestBase):
                 queue="my_queue",
                 routing_key='my_queue')
 
-    def test_bind_queue_to_exchange_connection_closed(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_bind_queue_to_exchange_connection_closed(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -161,8 +154,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.queue_bind.call_count == 2
             assert mock_pika.call_count == 1  # No retry
 
-    def test_bind_queue_to_exchange_channel_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_bind_queue_to_exchange_channel_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -188,8 +180,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.queue_bind.call_count == 1
             assert mock_pika.call_count == 1  # No retry
 
-    def test_bind_queue_to_exchange_connection_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_bind_queue_to_exchange_connection_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -216,8 +207,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.queue_bind.call_count == 2
             assert mock_pika.call_count == 2  # Retried the connection
 
-    def test_basic_publish(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_basic_publish(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -237,8 +227,7 @@ class TestRabbitAdaptor(ResourceTestBase):
                 properties=pika.BasicProperties(delivery_mode=1),
                 body="{my: body}")
 
-    def test_basic_publish_connection_closed(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_basic_publish_connection_closed(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -260,8 +249,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.basic_publish.call_count == 2
             assert mock_pika.call_count == 1  # No retry of connection
 
-    def test_basic_publish_channel_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_basic_publish_channel_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -282,8 +270,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.basic_publish.call_count == 1
             assert mock_pika.call_count == 1  # No retry of connection
 
-    def test_basic_publish_connection_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_basic_publish_connection_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -305,8 +292,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.basic_publish.call_count == 2
             assert mock_pika.call_count == 2
 
-    def test_setup_exchange(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_exchange(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -322,8 +308,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             mock_channel.exchange_declare.assert_called_with(
                 exchange="exchange1")
 
-    def test_setup_exchange_connection_closed(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_exchange_connection_closed(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -345,8 +330,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.exchange_declare.call_count == 2
             assert mock_pika.call_count == 2
 
-    def test_setup_exchange_channel_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_exchange_channel_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -368,8 +352,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.exchange_declare.call_count == 2
             assert mock_pika.call_count == 2  # Retry on channel error
 
-    def test_setup_exchange_connection_error(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_setup_exchange_connection_error(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -391,8 +374,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             assert mock_channel.exchange_declare.call_count == 2
             assert mock_pika.call_count == 2
 
-    def test_close_channel(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_close_channel(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_channel = mocker.Mock()
@@ -411,8 +393,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             rabbit.close_channel()
             mock_channel.close.assert_called()
 
-    def test_close_connection(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_close_connection(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_connection.close = mocker.Mock()
@@ -432,8 +413,7 @@ class TestRabbitAdaptor(ResourceTestBase):
             rabbit.close_connection()
             mock_connection.close.assert_called()
 
-    def test_channel_acessro(self, mocker, mock_rabbit_adaptor):
-        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+    def test_channel_acessro(self, mocker, client):
         with client.application.app_context():
             mock_connection = mocker.Mock()
             mock_connection.close = mocker.Mock()

--- a/tests/web/web_test_base.py
+++ b/tests/web/web_test_base.py
@@ -64,14 +64,12 @@ class WebTestBase:
         }
 
     @staticmethod
-    def _test_client(mocker, extra_config=None):
+    def _test_client(extra_config=None):
         from servicex import create_app
-        from servicex.rabbit_adaptor import RabbitAdaptor
         config = WebTestBase._app_config()
         if extra_config:
             config.update(extra_config)
-        mock_rabbit_adaptor = mocker.MagicMock(RabbitAdaptor)
-        app = create_app(config, provided_rabbit_adaptor=mock_rabbit_adaptor)
+        app = create_app(config)
         app.test_request_context().push()
         return app.test_client()
 
@@ -150,8 +148,8 @@ class WebTestBase:
         }
 
     @fixture
-    def client(self, mocker):
-        with self._test_client(mocker) as client:
+    def client(self):
+        with self._test_client() as client:
             yield client
 
     @fixture


### PR DESCRIPTION
Thanks to #96, we can reduce the amount of boilerplate in the unit test suite *considerably*.

In general, tests now work as follows:
- If the test does not require access to any mock adaptors (`RabbitAdaptor`, `LookupResultProcessor`, etc.), simply use the `client` fixture:
```python
def test_something(client):
    client.get(...)
```
- If the test requires access to an adaptor such as the `RabbitAdaptor` in order to change its behavior or make assertions, use the appropriate mock adaptor fixture (or create a mock manually in the test function), and then pass it to the `ResourceTestBase._test_client` method as before:
```python
def test_something_with_adaptor(mock_rabbit_adaptor):
    client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
    mock_rabbit_adaptor.assert_called_with(...)
```
- Most tests no longer need to create a test client manually, but it may also still be necessary if you want to pass in some custom configuration values:
```python
def test_something_with_custom_config():
    client = self._test_client(extra_config={"ENABLE_AUTH": True})
    ...
```

There's still quite a bit of duplicated code throughout the unit test suite that should be refactored to Pytest fixtures, but this is a good start.