### PR TITLE
Add transformation request web route

### DIFF
--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -126,6 +126,7 @@ def create_app(test_config=None,
         @app.context_processor
         def inject_modules():
             import humanize
-            return dict(humanize=humanize)
+            import datetime
+            return dict(datetime=datetime, humanize=humanize)
 
     return app

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -122,4 +122,10 @@ def create_app(test_config=None,
         add_routes(api, transformer_manager, rabbit_adaptor, object_store, code_gen_service,
                    lookup_result_processor, docker_repo_adapter)
 
+        # Inject useful Python modules to make them available in all templates
+        @app.context_processor
+        def inject_modules():
+            import humanize
+            return dict(humanize=humanize)
+
     return app

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -53,8 +53,15 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.resources.users.pending_users import PendingUsers
     from servicex.resources.users.slack_interaction import SlackInteraction
 
-    from servicex.web import home, sign_in, sign_out, auth_callback, \
-        view_profile, edit_profile, api_token, servicex_file
+    from servicex.web.home import home
+    from servicex.web.sign_in import sign_in
+    from servicex.web.sign_out import sign_out
+    from servicex.web.auth_callback import auth_callback
+    from servicex.web.view_profile import view_profile
+    from servicex.web.edit_profile import edit_profile
+    from servicex.web.api_token import api_token
+    from servicex.web.servicex_file import servicex_file
+    from servicex.web.transformation_request import transformation_request
 
     # Must be its own module to allow patching
     from servicex.web.create_profile import create_profile
@@ -77,6 +84,11 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
                      methods=['GET', 'POST'])
     app.add_url_rule('/profile/edit', 'edit_profile', edit_profile,
                      methods=['GET', 'POST'])
+    app.add_url_rule(
+        '/transformation-request/<id_>',
+        'transformation_request',
+        transformation_request
+    )
 
     # User management and Authentication Endpoints
     api.add_resource(TokenRefresh, '/token/refresh')

--- a/servicex/templates/transformation_request.html
+++ b/servicex/templates/transformation_request.html
@@ -9,7 +9,7 @@
       <dd class="col-sm-9">{{ req.title or "Untitled" }}</dd>
 
       <dt class="col-sm-3">ID</dt>
-      <dd class="col-sm-9">{{ req.id}}</dd>
+      <dd class="col-sm-9">{{ req.id }}</dd>
 
       <dt class="col-sm-3">Request ID</dt>
       <dd class="col-sm-9">{{ req.request_id }}</dd>

--- a/servicex/templates/transformation_request.html
+++ b/servicex/templates/transformation_request.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="content-section">
+    <div class="row justify-content-between align-items-center">
+      <h4 class="mb-3 col-auto">Transformation Request</h4>
+    </div>
+    <dl class="row">
+      <dt class="col-sm-3">Title</dt>
+      <dd class="col-sm-9">{{ req.title or "Default title" }}</dd>
+
+      <dt class="col-sm-3">ID</dt>
+      <dd class="col-sm-9">{{ req.id}}</dd>
+
+      <dt class="col-sm-3">Request ID</dt>
+      <dd class="col-sm-9">{{ req.request_id }}</dd>
+
+      <dt class="col-sm-3">Status</dt>
+      <dd class="col-sm-9">{{ req.status }}</dd>
+
+    {% if config['ENABLE_AUTH'] %}
+      <dt class="col-sm-3">Submitted by</dt>
+      <dd class="col-sm-9">{{ req.submitter_name }}</dd>
+    {% endif %}
+
+      <dt class="col-sm-3">Submitted at</dt>
+      <dd class="col-sm-9">{{ req.submit_time.strftime("%Y-%m-%d %H:%M:%S") }}</dd>
+
+      <dt class="col-sm-3">Data ID</dt>
+      <dd class="col-sm-9" style="word-break: break-all">{{ req.did }}</dd>
+
+      <dt class="col-sm-3">Selection</dt>
+      <dd class="col-sm-9">{{ req.selection }}</dd>
+
+      <dt class="col-sm-3">Files</dt>
+      <dd class="col-sm-9">{{ humanize.intcomma(req.files) }}</dd>
+
+      <dt class="col-sm-3">Files Remaining</dt>
+      <dd class="col-sm-9">{{ humanize.intcomma(req.files_remaining) }}</dd>
+
+      <dt class="col-sm-3">Files Skipped</dt>
+      <dd class="col-sm-9">{{ humanize.intcomma(req.files_skipped) }}</dd>
+
+      <dt class="col-sm-3">Total Events</dt>
+      <dd class="col-sm-9">{{ humanize.intcomma(req.total_events) }}</dd>
+
+      <dt class="col-sm-3">Total Size</dt>
+      <dd class="col-sm-9">{{ humanize.naturalsize(req.total_bytes or 0) }}</dd>
+
+      <dt class="col-sm-3">DID Lookup Time</dt>
+      <dd class="col-sm-9">{{ req.did_lookup_time }}s</dd>
+
+    {% if req.failure_description %}
+      <dt class="col-sm-3">Failure Description</dt>
+      <dd class="col-sm-9">{{ req.failure_description }} s</dd>
+    {% endif %}
+
+    </dl>
+  </div>
+{% endblock %}

--- a/servicex/templates/transformation_request.html
+++ b/servicex/templates/transformation_request.html
@@ -6,7 +6,7 @@
     </div>
     <dl class="row">
       <dt class="col-sm-3">Title</dt>
-      <dd class="col-sm-9">{{ req.title or "Default title" }}</dd>
+      <dd class="col-sm-9">{{ req.title or "Untitled" }}</dd>
 
       <dt class="col-sm-3">ID</dt>
       <dd class="col-sm-9">{{ req.id}}</dd>

--- a/servicex/web/transformation_request.py
+++ b/servicex/web/transformation_request.py
@@ -3,16 +3,16 @@ from datetime import timedelta
 from flask import render_template, abort
 import humanize
 
+from servicex.decorators import oauth_required
 from servicex.models import TransformRequest, db
 
 
+@oauth_required
 def transformation_request(id_: str):
-    print(id_)
     if id_.isnumeric():
         req = TransformRequest.query.get(id_)
     else:
         req = db.session.query(TransformRequest).filter_by(request_id=id_).one()
-    print(req)
     if not req:
         abort(404)
     return render_template(

--- a/servicex/web/transformation_request.py
+++ b/servicex/web/transformation_request.py
@@ -1,10 +1,7 @@
-from datetime import timedelta
-
 from flask import render_template, abort
-import humanize
 
 from servicex.decorators import oauth_required
-from servicex.models import TransformRequest, db
+from servicex.models import TransformRequest
 
 
 @oauth_required
@@ -12,9 +9,7 @@ def transformation_request(id_: str):
     if id_.isnumeric():
         req = TransformRequest.query.get(id_)
     else:
-        req = db.session.query(TransformRequest).filter_by(request_id=id_).one()
+        req = TransformRequest.query.filter_by(request_id=id_).one()
     if not req:
         abort(404)
-    return render_template(
-        'transformation_request.html', req=req, humanize=humanize, timedelta=timedelta
-    )
+    return render_template('transformation_request.html', req=req)

--- a/servicex/web/transformation_request.py
+++ b/servicex/web/transformation_request.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+from flask import render_template, abort
+import humanize
+
+from servicex.models import TransformRequest, db
+
+
+def transformation_request(id_: str):
+    print(id_)
+    if id_.isnumeric():
+        req = TransformRequest.query.get(id_)
+    else:
+        req = db.session.query(TransformRequest).filter_by(request_id=id_).one()
+    print(req)
+    if not req:
+        abort(404)
+    return render_template(
+        'transformation_request.html', req=req, humanize=humanize, timedelta=timedelta
+    )

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
         'psycopg2',
         'globus_sdk',
         'cryptography',
-        'bootstrap-flask'
+        'bootstrap-flask',
+        'humanize'
     ],
     extras_require={
         'test': [

--- a/tests/web/test_transformation_request.py
+++ b/tests/web/test_transformation_request.py
@@ -1,0 +1,42 @@
+from flask import Response, url_for, render_template
+
+from pytest import fixture
+
+from .web_test_base import WebTestBase
+
+
+class TestTransformationRequest(WebTestBase):
+
+    @fixture
+    def mock_tr(self, mocker):
+        return mocker.patch("servicex.web.transformation_request.TransformRequest")
+
+    def test_get_by_primary_key(self, client, mock_tr):
+        req = self._test_transformation_req()
+        mock_tr.query.get.return_value = req
+        resp: Response = client.get(url_for('transformation_request', id_=req.id))
+        assert resp.status_code == 200
+        assert resp.data.decode() == render_template(
+            'transformation_request.html', req=req
+        )
+        mock_tr.query.get.assert_called_once_with(str(req.id))
+        mock_tr.query.filter_by.assert_not_called()
+
+    def test_get_by_uuid(self, client, mocker, mock_tr):
+        req = self._test_transformation_req()
+        mock_query = mocker.MagicMock()
+        mock_tr.query.filter_by.return_value = mock_query
+        mock_query.one.return_value = req
+        resp: Response = client.get(url_for('transformation_request', id_=req.request_id))
+        assert resp.status_code == 200
+        assert resp.data.decode() == render_template(
+            'transformation_request.html', req=req
+        )
+        mock_tr.query.filter_by.assert_called_once_with(request_id=req.request_id)
+        mock_tr.query.get.assert_not_called()
+        mock_query.one.assert_called_once()
+
+    def test_404(self, client, mock_tr):
+        mock_tr.query.get.return_value = None
+        resp: Response = client.get(url_for('transformation_request', id_=1))
+        assert resp.status_code == 404

--- a/tests/web/web_test_base.py
+++ b/tests/web/web_test_base.py
@@ -25,6 +25,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime
+
 from pytest import fixture
 
 
@@ -147,6 +149,16 @@ class WebTestBase:
             "iat": 1595955388,
             "sub": "primary-oauth-id"
         }
+
+    @staticmethod
+    def _test_transformation_req():
+        from servicex.models import TransformRequest
+        return TransformRequest(
+            id=1234,
+            did="foo",
+            request_id="b5901cca-9858-42e7-a093-0929cf391f0e",
+            submit_time=datetime.utcnow(),
+        )
 
     @fixture
     def client(self):


### PR DESCRIPTION
This PR adds a new web route at `/transformation-request/<id>`, which displays detailed information about a single transformation request. Note that `id` can be either the autoincremented integer used as the primary key in the database or the `request_id`, which is the generated UUID used in many other places throughout the back end.

![image](https://user-images.githubusercontent.com/5485577/116797837-0fc1de00-aab8-11eb-9c48-f9fd4c425451.png)

Partially replaces #79.
