### PR TITLE
Add dashboard for transformation requests

### DIFF
--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -57,6 +57,8 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.web.sign_in import sign_in
     from servicex.web.sign_out import sign_out
     from servicex.web.auth_callback import auth_callback
+    from servicex.web.user_dashboard import user_dashboard
+    from servicex.web.global_dashboard import global_dashboard
     from servicex.web.view_profile import view_profile
     from servicex.web.edit_profile import edit_profile
     from servicex.web.api_token import api_token
@@ -74,11 +76,13 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
 
     # Web Frontend Routes
     app.add_url_rule('/', 'home', home)
+    app.add_url_rule('/global-dashboard', 'global-dashboard', global_dashboard)
     app.add_url_rule('/sign-in', 'sign_in', sign_in)
     app.add_url_rule('/sign-out', 'sign_out', sign_out)
     app.add_url_rule('/auth-callback', 'auth_callback', auth_callback)
     app.add_url_rule('/api-token', 'api_token', api_token)
     app.add_url_rule('/.servicex', 'servicex-file', servicex_file)
+    app.add_url_rule('/dashboard', 'user-dashboard', user_dashboard)
     app.add_url_rule('/profile', 'profile', view_profile)
     app.add_url_rule('/profile/new', 'create_profile', create_profile,
                      methods=['GET', 'POST'])

--- a/servicex/static/main.css
+++ b/servicex/static/main.css
@@ -1,7 +1,8 @@
 body {
   background: #fafafa;
   color: #333333;
-  margin-top: 5rem;
+  margin-top: 56px;
+  padding: 20px 0;
 }
 
 .site-header .navbar-nav .nav-link {
@@ -18,7 +19,7 @@ body {
 
 .content-section {
   background: #ffffff;
-  padding: 10px 20px;
+  padding: 20px;
   border: 1px solid #dddddd;
   border-radius: 3px;
   margin-bottom: 20px;

--- a/servicex/templates/authenticated-base.html
+++ b/servicex/templates/authenticated-base.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% from 'bootstrap/nav.html' import render_nav_item %}
+
+
+{% block nav %}
+  <ul class="nav nav-pills mb-4">
+    {{ render_nav_item('user-dashboard', 'Dashboard') }}
+    {{ render_nav_item('profile', 'Profile') }}
+  </ul>
+{% endblock %}

--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -33,24 +33,23 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarToggle">
         <div class="navbar-nav mr-auto">
-          <a class="nav-item nav-link"
-             href="{{ config['DOCS_BASE_URL'] }}">
-            Docs
-          </a>
+          <a class="nav-item nav-link" href="{{ config['DOCS_BASE_URL'] }}">Docs</a>
+        {% if not config['ENABLE_AUTH'] %}
+          <a href="{{ url_for('global-dashboard') }}" class="nav-item nav-link">Dashboard</a>
+        {% endif %}
         </div>
         <!-- Navbar Right Side -->
         {% if config['ENABLE_AUTH'] %}
           <div class="navbar-nav">
           {% if not session['is_authenticated'] %}
             <a href="{{ url_for('sign_in') }}" class="nav-item nav-link">Sign In</a>
-            <a href="{{ url_for('global-dashboard') }}" class="nav-item nav-link">Dashboard</a>
           {% else %}
             <a href=" {{ url_for('user-dashboard') }}" class="nav-item nav-link">{{ session['name'] }}</a>
             <a href="{{ url_for('sign_out') }}" class="nav-item nav-link">
               <i class="fa fa-sign-out" aria-hidden="true"></i>
             </a>
           {% endif %}
-        </div>
+          </div>
         {% endif %}
       </div>
     </div>

--- a/servicex/templates/base.html
+++ b/servicex/templates/base.html
@@ -42,10 +42,11 @@
         {% if config['ENABLE_AUTH'] %}
           <div class="navbar-nav">
           {% if not session['is_authenticated'] %}
-            <a href="/sign-in" class="nav-item nav-link">Sign In</a>
+            <a href="{{ url_for('sign_in') }}" class="nav-item nav-link">Sign In</a>
+            <a href="{{ url_for('global-dashboard') }}" class="nav-item nav-link">Dashboard</a>
           {% else %}
-            <a href="/profile" class="nav-item nav-link">{{ session['name'] }}</a>
-            <a href="/sign-out" class="nav-item nav-link">
+            <a href=" {{ url_for('user-dashboard') }}" class="nav-item nav-link">{{ session['name'] }}</a>
+            <a href="{{ url_for('sign_out') }}" class="nav-item nav-link">
               <i class="fa fa-sign-out" aria-hidden="true"></i>
             </a>
           {% endif %}
@@ -57,6 +58,9 @@
 </header>
 
 <main role="main" class="container">
+  <div class="row">
+    {% block nav %}{% endblock %}
+  </div>
   <div class="row">
     <div class="col-md-12">
       {% with messages = get_flashed_messages(with_categories=true) %}
@@ -91,6 +95,11 @@
     // Enable tooltips
     $(function () {
         $('[data-toggle="tooltip"]').tooltip({trigger: 'hover'})
+    })
+
+    // Mark current endpoint as active
+    $(document).ready(function () {
+      $("#{{request.endpoint}}").addClass("active");
     })
 </script>
 

--- a/servicex/templates/get_started.html
+++ b/servicex/templates/get_started.html
@@ -1,0 +1,14 @@
+<div>
+  <div class="row justify-content-center">
+    <h5>Get Started</h5>
+  </div>
+  <p style="text-align: center">
+    Check out our guide to making your first transformation request.
+    Recent requests will show up here.
+  </p>
+  <div class="row justify-content-center">
+    <a class="btn btn-outline-primary" href="{{ config['DOCS_BASE_URL']}}/user/getting-started" role="button">
+      Go to Docs
+    </a>
+  </div>
+</div>

--- a/servicex/templates/global_dashboard.html
+++ b/servicex/templates/global_dashboard.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% from 'requests_table.html' import requests_table, requests_table_update_script %}
+
+{% block content %}
+
+  <div>
+    <div class="content-section">
+      <h4 class="mb-3">Transformation Requests</h4>
+      {{ requests_table(pagination, humanize) }}
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {{ requests_table_update_script(pagination) }}
+{% endblock %}

--- a/servicex/templates/profile.html
+++ b/servicex/templates/profile.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "authenticated-base.html" %}
 {% block content %}
   <div class="content-section">
     <div class="row justify-content-between align-items-center">

--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -6,10 +6,9 @@
   <table class="table">
     <thead class="thead-dark">
       <tr>
-        <th scope="col">ID</th>
+        <th scope="col">Title</th>
         {% if config['ENABLE_AUTH'] %}<th scope="col">Submitted by</th>{% endif %}
-        <th scope="col">Submitted at</th>
-        <th scope="col">Age</th>
+        <th scope="col">Submit time</th>
         <th scope="col">Status</th>
         <th scope="col">Files completed</th>
         <th scope="col">Workers</th>
@@ -23,7 +22,6 @@
         </th>
         {% if config['ENABLE_AUTH'] %}<td>{{ req.submitter_name }}</td>{% endif %}
         <td>{{ req.submit_time.strftime("%Y-%m-%d %H:%M:%S") }}</td>
-        <td>{{ humanize.naturaldelta(req.age) }}</td>
         <td>
           <div id="status-{{ req.request_id }}">
             {{ req.status }}
@@ -37,7 +35,8 @@
         </td>
         <td>
           <div>
-            <span id="files-processed-{{ req.request_id }}">{{ humanize.intcomma(req.files_processed) }}</span> of {{ humanize.intcomma(req.files) }}</div>
+            <span id="files-processed-{{ req.request_id }}">{{ humanize.intcomma(req.files_processed) }}</span> of
+            <span>{{ humanize.intcomma(req.files or "Unknown") }}</span></div>
           <div id="files-failed-{{ req.request_id }}">
             {% if req.files_failed %}({{ req.files_failed }} failed){% endif %}
           </div>
@@ -66,7 +65,7 @@
         return fetch(document.location.origin + `/servicex/transformation/${req_id}/deployment-status`)
           .then((resp) => resp.json())
           .then((data) => {
-            console.log(`${req_id} deployment`, data);
+            {#console.log(`${req_id} deployment`, data);#}
             $(`#replicas-${req_id}`).text(data["replicas"]);
           });
       }));
@@ -78,7 +77,7 @@
         return fetch(document.location.origin + `/servicex/transformation/${req_id}/status`)
           .then((resp) => resp.json())
           .then((data) => {
-            console.log(`${req_id} status`, data);
+            {#console.log(`${req_id} status`, data);#}
             const status = data["status"];
             const processed = data["files-processed"];
             const remaining = data["files-remaining"];

--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -1,0 +1,112 @@
+{% from 'bootstrap/table.html' import render_table %}
+{% from 'bootstrap/pagination.html' import render_pager %}
+{% from 'bootstrap/pagination.html' import render_pagination %}
+
+{% macro requests_table(pagination, humanize) %}
+  <table class="table">
+    <thead class="thead-dark">
+      <tr>
+        <th scope="col">ID</th>
+        {% if config['ENABLE_AUTH'] %}<th scope="col">Submitted by</th>{% endif %}
+        <th scope="col">Submitted at</th>
+        <th scope="col">Age</th>
+        <th scope="col">Status</th>
+        <th scope="col">Files completed</th>
+        <th scope="col">Workers</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for req in pagination.items %}
+      <tr>
+        <th scope="row" style="word-break: break-all">
+          <a href="/transformation-request/{{ req.id }}">{{ req.title or "Untitled" }}</a>
+        </th>
+        {% if config['ENABLE_AUTH'] %}<td>{{ req.submitter_name }}</td>{% endif %}
+        <td>{{ req.submit_time.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+        <td>{{ humanize.naturaldelta(req.age) }}</td>
+        <td>
+          <div id="status-{{ req.request_id }}">
+            {{ req.status }}
+          </div>
+        {% if req.incomplete %}
+          <div class="progress" id="progress-{{ req.request_id }}">
+            <div class="progress-bar progress-bar-striped progress-bar-animated" id="progress-bar-{{ req.request_id }}">
+            </div>
+          </div>
+        {% endif %}
+        </td>
+        <td>
+          <div>
+            <span id="files-processed-{{ req.request_id }}">{{ humanize.intcomma(req.files_processed) }}</span> of {{ humanize.intcomma(req.files) }}</div>
+          <div id="files-failed-{{ req.request_id }}">
+            {% if req.files_failed %}({{ req.files_failed }} failed){% endif %}
+          </div>
+        </td>
+        <td id="replicas-{{ req.request_id }}">-</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% if pagination.items %}
+    {{ render_pagination(pagination, align='center') }}
+  {% else %}
+    {% include "get_started.html" %}
+  {% endif %}
+{% endmacro %}
+
+{% macro requests_table_update_script(pagination) %}
+  <script>
+    let watched = new Set(
+      {{ pagination.items | selectattr("incomplete") | map(attribute="request_id") | list | tojson | safe }}
+    );
+    console.log(watched);
+
+    function update_replicas() {
+      Promise.all([...watched].map((req_id) => {
+        return fetch(document.location.origin + `/servicex/transformation/${req_id}/deployment-status`)
+          .then((resp) => resp.json())
+          .then((data) => {
+            console.log(`${req_id} deployment`, data);
+            $(`#replicas-${req_id}`).text(data["replicas"]);
+          });
+      }));
+      setTimeout(update_replicas, 30000);
+    }
+
+    function update_progress() {
+      Promise.all([...watched].map((req_id) => {
+        return fetch(document.location.origin + `/servicex/transformation/${req_id}/status`)
+          .then((resp) => resp.json())
+          .then((data) => {
+            console.log(`${req_id} status`, data);
+            const status = data["status"];
+            const processed = data["files-processed"];
+            const remaining = data["files-remaining"];
+            const failed = data["files-skipped"];
+            const progress = processed / (processed + failed + remaining) * 100;
+
+            $(`#status-${req_id}`).text(status);
+            $(`#files-processed-${req_id}`).text(processed);
+            const progressBar = $(`#progress-bar-${req_id}`)
+            progressBar.text(`${Math.floor(progress)}%`)
+            progressBar.css("width", `${progress}%`);
+            if (failed > 0) {
+              progressBar.addClass("bg-warning");
+              $(`#files-failed-${req_id}`).text(`(${failed} falied)`);
+            }
+            if (status === "Complete" || status === "Fatal") {
+              watched.delete(req_id);
+              $(`#progress-${req_id}`).remove();
+              $(`#replicas-${req_id}`).text("-")
+            }
+          })
+      }));
+      setTimeout(update_progress, 5000);
+    }
+
+    $(document).ready(function () {
+      update_replicas();
+      update_progress();
+    })
+  </script>
+{% endmacro %}

--- a/servicex/templates/user_dashboard.html
+++ b/servicex/templates/user_dashboard.html
@@ -1,0 +1,25 @@
+{% extends "authenticated-base.html" %}
+
+{% from 'requests_table.html' import requests_table, requests_table_update_script %}
+
+{% block content %}
+
+  <div>
+    <div class="content-section">
+      <div class="lead">
+        Welcome to ServiceX, {{ session['name'] }}!
+      </div>
+    </div>
+
+    <div class="content-section">
+      <h4 class="mb-3">Transformation Requests</h4>
+      {{ requests_table(pagination, humanize) }}
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {{ requests_table_update_script(pagination) }}
+{% endblock %}

--- a/servicex/web/auth_callback.py
+++ b/servicex/web/auth_callback.py
@@ -46,5 +46,5 @@ def auth_callback():
         if user:
             session['user_id'] = user.id
             session['admin'] = user.admin
-            return redirect(url_for('profile'))
+            return redirect(url_for('user-dashboard'))
     return redirect(url_for('create_profile'))

--- a/servicex/web/global_dashboard.py
+++ b/servicex/web/global_dashboard.py
@@ -1,0 +1,14 @@
+from flask import render_template, request
+from flask_sqlalchemy import Pagination
+
+from servicex.decorators import admin_required
+from servicex.models import TransformRequest
+
+
+@admin_required
+def global_dashboard():
+    page = request.args.get('page', 1, type=int)
+    pagination: Pagination = TransformRequest.query\
+        .order_by(TransformRequest.id.desc())\
+        .paginate(page=page, per_page=25, error_out=False)
+    return render_template("global_dashboard.html", pagination=pagination)

--- a/servicex/web/user_dashboard.py
+++ b/servicex/web/user_dashboard.py
@@ -12,8 +12,4 @@ def user_dashboard():
         .filter_by(submitted_by=session["user_id"])\
         .order_by(TransformRequest.id.desc())\
         .paginate(page=page, per_page=15, error_out=False)
-    return render_template(
-        "user_dashboard.html",
-        transformation_requests=pagination.items,
-        pagination=pagination
-    )
+    return render_template("user_dashboard.html", pagination=pagination)

--- a/servicex/web/user_dashboard.py
+++ b/servicex/web/user_dashboard.py
@@ -1,0 +1,19 @@
+from flask import render_template, request, session
+from flask_sqlalchemy import Pagination
+
+from servicex.decorators import oauth_required
+from servicex.models import TransformRequest
+
+
+@oauth_required
+def user_dashboard():
+    page = request.args.get('page', 1, type=int)
+    pagination: Pagination = TransformRequest.query\
+        .filter_by(submitted_by=session["user_id"])\
+        .order_by(TransformRequest.id.desc())\
+        .paginate(page=page, per_page=15, error_out=False)
+    return render_template(
+        "user_dashboard.html",
+        transformation_requests=pagination.items,
+        pagination=pagination
+    )

--- a/tests/web/test_auth_callback.py
+++ b/tests/web/test_auth_callback.py
@@ -35,4 +35,4 @@ class TestAuthCallback(WebTestBase):
         assert session.get('name') == id_token['name']
         assert session.get('sub') == id_token['sub']
         assert response.status_code == 302
-        assert response.location == url_for('profile', _external=True)
+        assert response.location == url_for('user-dashboard', _external=True)

--- a/tests/web/test_global_dashboard.py
+++ b/tests/web/test_global_dashboard.py
@@ -1,0 +1,31 @@
+from flask import Response, url_for, render_template
+from flask_sqlalchemy import Pagination
+
+from pytest import fixture
+
+from .web_test_base import WebTestBase
+
+
+class TestGlobalDashboard(WebTestBase):
+
+    @fixture
+    def mock_query(self, mocker):
+        mock_tr = mocker.patch("servicex.web.global_dashboard.TransformRequest")
+        return mock_tr.query.order_by.return_value
+
+    def test_get_empty_state(self, client, user, mock_query):
+        pagination = Pagination(mock_query, page=1, per_page=15, total=0, items=[])
+        mock_query.paginate.return_value = pagination
+        response: Response = client.get(url_for('global-dashboard'))
+        assert response.status_code == 200
+        expected = render_template('global_dashboard.html', pagination=pagination)
+        assert response.data.decode() == expected
+
+    def test_get_with_results(self, client, user, mock_query):
+        items = [self._test_transformation_req(id=i+1) for i in range(3)]
+        pagination = Pagination(mock_query, page=1, per_page=15, total=100, items=items)
+        mock_query.paginate.return_value = pagination
+        response: Response = client.get(url_for('global-dashboard'))
+        assert response.status_code == 200
+        expected = render_template('global_dashboard.html', pagination=pagination)
+        assert response.data.decode() == expected

--- a/tests/web/test_user_dashboard.py
+++ b/tests/web/test_user_dashboard.py
@@ -1,0 +1,35 @@
+from flask import Response, url_for, render_template
+from flask_sqlalchemy import Pagination
+
+from pytest import fixture
+
+from .web_test_base import WebTestBase
+
+
+class TestUserDashboard(WebTestBase):
+
+    @fixture
+    def mock_query(self, mocker):
+        mock_tr = mocker.patch("servicex.web.user_dashboard.TransformRequest")
+        return mock_tr.query.filter_by.return_value.order_by.return_value
+
+    def test_get_empty_state(self, client, user, mock_query):
+        with client.session_transaction() as sess:
+            sess['user_id'] = user.id
+        pagination = Pagination(mock_query, page=1, per_page=15, total=0, items=[])
+        mock_query.paginate.return_value = pagination
+        response: Response = client.get(url_for('user-dashboard'))
+        assert response.status_code == 200
+        expected = render_template('user_dashboard.html', pagination=pagination)
+        assert response.data.decode() == expected
+
+    def test_get_with_results(self, client, user, mock_query):
+        with client.session_transaction() as sess:
+            sess['user_id'] = user.id
+        items = [self._test_transformation_req(id=i+1) for i in range(3)]
+        pagination = Pagination(mock_query, page=1, per_page=15, total=100, items=items)
+        mock_query.paginate.return_value = pagination
+        response: Response = client.get(url_for('user-dashboard'))
+        assert response.status_code == 200
+        expected = render_template('user_dashboard.html', pagination=pagination)
+        assert response.data.decode() == expected

--- a/tests/web/test_view_profile.py
+++ b/tests/web/test_view_profile.py
@@ -6,7 +6,7 @@ from .web_test_base import WebTestBase
 class TestViewProfile(WebTestBase):
     def test_view_profile(self, client, user):
         with client.session_transaction() as sess:
-            sess['sub'] = 'janedoe'
+            sess['sub'] = user.sub
         response: Response = client.get(url_for('profile'))
         assert response.status_code == 200
         assert response.data.decode() == render_template('profile.html', user=user)

--- a/tests/web/web_test_base.py
+++ b/tests/web/web_test_base.py
@@ -151,14 +151,16 @@ class WebTestBase:
         }
 
     @staticmethod
-    def _test_transformation_req():
+    def _test_transformation_req(**kwargs):
         from servicex.models import TransformRequest
-        return TransformRequest(
-            id=1234,
-            did="foo",
-            request_id="b5901cca-9858-42e7-a093-0929cf391f0e",
-            submit_time=datetime.utcnow(),
-        )
+        defaults = {
+            "id": 1234,
+            "did": "foo",
+            "request_id": "b5901cca-9858-42e7-a093-0929cf391f0e",
+            "submit_time": datetime.utcnow()
+        }
+        defaults.update(kwargs)
+        return TransformRequest(**defaults)
 
     @fixture
     def client(self):


### PR DESCRIPTION
This PR contains two new web routes:
- `/dashboard` displays user-specific transformation requests in a paginated table, linking to their individual pages. For ongoing requests, progress bars are displayed and updated at regular intervals.
- `/global-dashboard` displays the same information as the above for all transformation requests in the database. This route is shown in the header if auth is disabled. If auth is enabled, this route is restricted to administrators.

Replaces the remainder of #79.