### PR TITLE
Restore autoscaling configuration; use the correct number of initial replicas

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -48,6 +48,10 @@ TRANSFORMER_MANAGER_ENABLED = True
 # start the requested number of transformers
 TRANSFORMER_AUTOSCALE_ENABLED = True
 
+# Set min and max replicas for autoscaler
+TRANSFORMER_MIN_REPLICAS = 1
+TRANSFORMER_MAX_REPLICAS = 20
+
 # Use one core per transformer
 TRANSFORMER_CPU_LIMIT = 1
 

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -165,24 +165,25 @@ class TransformerManager:
         return deployment
 
     @staticmethod
-    def create_hpa_object(request_id, workers):
+    def create_hpa_object(request_id):
         target = client.V1CrossVersionObjectReference(
             api_version="apps/v1",
             kind='Deployment',
             name="transformer-" + request_id
         )
 
+        cfg = current_app.config
+        spec = client.V1HorizontalPodAutoscalerSpec(
+            scale_target_ref=target,
+            target_cpu_utilization_percentage=cfg["TRANSFORMER_CPU_SCALE_THRESHOLD"],
+            min_replicas=cfg["TRANSFORMER_MIN_REPLICAS"],
+            max_replicas=cfg["TRANSFORMER_MAX_REPLICAS"]
+        )
         hpa = client.V1HorizontalPodAutoscaler(
             api_version="autoscaling/v1",
             kind='HorizontalPodAutoscaler',
             metadata=client.V1ObjectMeta(name="transformer-" + request_id),
-            spec=client.V1HorizontalPodAutoscalerSpec(
-                max_replicas=workers,
-                scale_target_ref=target,
-                target_cpu_utilization_percentage=current_app.config[
-                    'TRANSFORMER_CPU_SCALE_THRESHOLD'
-                    ]
-            )
+            spec=spec
         )
 
         return hpa
@@ -217,7 +218,7 @@ class TransformerManager:
 
         if current_app.config['TRANSFORMER_AUTOSCALE_ENABLED']:
             autoscaler_api = kubernetes.client.AutoscalingV1Api()
-            hpa = self.create_hpa_object(request_id, workers)
+            hpa = self.create_hpa_object(request_id)
             self._create_hpa(autoscaler_api, hpa, namespace)
 
     @staticmethod

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -148,7 +148,10 @@ class TransformerManager:
             })
 
         # If we are using Autoscaler then always start with one replica
-        replicas = 1 if current_app.config['TRANSFORMER_AUTOSCALE_ENABLED'] else workers
+        if current_app.config['TRANSFORMER_AUTOSCALE_ENABLED']:
+            replicas = current_app.config.get('TRANSFORMER_MIN_REPLICAS', 1)
+        else:
+            replicas = workers
         spec = client.V1DeploymentSpec(
             template=template,
             selector=selector,

--- a/tests/resource_test_base.py
+++ b/tests/resource_test_base.py
@@ -53,6 +53,8 @@ class ResourceTestBase:
             'TRANSFORMER_NAMESPACE': "my-ws",
             'TRANSFORMER_MANAGER_ENABLED': False,
             'TRANSFORMER_AUTOSCALE_ENABLED': True,
+            'TRANSFORMER_MIN_REPLICAS': 1,
+            'TRANSFORMER_MAX_REPLICAS': 5,
             'ADVERTISED_HOSTNAME': 'cern.analysis.ch:5000',
             'TRANSFORMER_PULL_POLICY': 'Always',
             'TRANSFORMER_VALIDATE_DOCKER_IMAGE': True,

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -91,7 +91,7 @@ class TestTransformerManager(ResourceTestBase):
                 result_destination='kafka', result_format='arrow', x509_secret='x509',
                 generated_code_cm=None)
             called_deployment = mock_api.mock_calls[1][2]['body']
-            assert called_deployment.spec.replicas == 1
+            assert called_deployment.spec.replicas == cfg['TRANSFORMER_MIN_REPLICAS']
             assert len(called_deployment.spec.template.spec.containers) == 1
             container = called_deployment.spec.template.spec.containers[0]
             assert container.image == 'sslhep/servicex-transformer:pytest'

--- a/tests/test_transformer_manager.py
+++ b/tests/test_transformer_manager.py
@@ -77,11 +77,12 @@ class TestTransformerManager(ResourceTestBase):
         transformer = TransformerManager('external-kubernetes')
         cfg = {
             'TRANSFORMER_CPU_LIMIT': 4,
-            'TRANSFORMER_CPU_SCALE_THRESHOLD': 30
+            'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
+            'TRANSFORMER_MIN_REPLICAS': 3,
+            'TRANSFORMER_MAX_REPLICAS': 17,
         }
-        client = self._test_client(
-            extra_config=cfg, transformation_manager=transformer,
-        )
+        client = self._test_client(transformation_manager=transformer,
+                                   extra_config=cfg)
 
         with client.application.app_context():
             transformer.launch_transformer_jobs(
@@ -108,6 +109,7 @@ class TestTransformerManager(ResourceTestBase):
             assert mock_api.mock_calls[1][2]['namespace'] == 'my-ns'
             mock_autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_called()
             autoscaling_spec = mock_autoscaling.mock_calls[0][2]['body'].spec
+            assert autoscaling_spec.min_replicas == 3
             assert autoscaling_spec.max_replicas == 17
             assert autoscaling_spec.scale_target_ref.name == 'transformer-1234'
             assert autoscaling_spec.target_cpu_utilization_percentage == 30


### PR DESCRIPTION
This reverts commit 058377eb77de1f93c7e3593bdd8774364729c19f, in which I accidentally removed changes made in #77.

There is also a small fix to start the deployment with the number of replicas specified in `TRANSFORMER_MIN_REPLICAS`.