### PR TITLE
Strip off did scheme before passing to DID finder

### DIFF
--- a/servicex/did_parser.py
+++ b/servicex/did_parser.py
@@ -55,3 +55,11 @@ class DIDParser:
         :return: queue name
         """
         return f"{self.scheme}_did_requests"
+
+    @property
+    def full_did(self) -> str:
+        """
+        Reconstruct the full DID with scheme - this is useful if the scheme was defaulted
+        :return:
+        """
+        return f'{self.scheme}://{self.did}'

--- a/tests/resources/test_submit_transformation_request.py
+++ b/tests/resources/test_submit_transformation_request.py
@@ -40,7 +40,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
     @staticmethod
     def _generate_transformation_request(**kwargs):
         request = {
-            'did': '123-45-678',
+            'did': 'rucio://123-45-678',
             'columns': "e.e, e.p",
             'result-destination': 'kafka',
             'kafka': {'broker': 'ssl.hep.kafka:12332'},
@@ -116,7 +116,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         with client.application.app_context():
             saved_obj = TransformRequest.return_request(request_id)
             assert saved_obj
-            assert saved_obj.did == '123-45-678'
+            assert saved_obj.did == 'rucio://123-45-678'
             assert saved_obj.request_id == request_id
             assert saved_obj.title is None
             assert saved_obj.columns == "e.e, e.p"
@@ -156,6 +156,33 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             body=json.dumps(publish_body)
         )
 
+    def test_submit_transformation_default_scheme(self, mock_rabbit_adaptor, mock_app_version):
+        client = self._test_client(rabbit_adaptor=mock_rabbit_adaptor)
+        request = self._generate_transformation_request()
+        request['did'] = '123-45-678'  # No scheme
+
+        response = client.post('/servicex/transformation', json=request)
+        assert response.status_code == 200
+        request_id = response.json['request_id']
+        with client.application.app_context():
+            saved_obj = TransformRequest.return_request(request_id)
+            assert saved_obj
+            assert saved_obj.did == 'rucio://123-45-678'
+
+        service_endpoint = \
+            "http://cern.analysis.ch:5000/servicex/internal/transformation/" + \
+            request_id
+        publish_body = {
+            "request_id": request_id,
+            "did": "123-45-678",
+            "service-endpoint": service_endpoint
+        }
+        mock_rabbit_adaptor.basic_publish.assert_called_with(
+            exchange='',
+            routing_key='rucio_did_requests',
+            body=json.dumps(publish_body)
+        )
+
     def test_submit_transformation_with_root_file(
         self, mocker, mock_rabbit_adaptor, mock_code_gen_service, mock_app_version
     ):
@@ -173,7 +200,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         with client.application.app_context():
             saved_obj = TransformRequest.return_request(request_id)
             assert saved_obj
-            assert saved_obj.did == '123-45-678'
+            assert saved_obj.did == 'rucio://123-45-678'
             assert saved_obj.request_id == request_id
             assert saved_obj.columns is None
             assert saved_obj.selection == 'test-string'


### PR DESCRIPTION
# Problem
If the user supplies a scheme for the DID, this gets passed into the DID finder, however if the scheme is defaulted there it is not included in the DID Finder requests

Fixes #116 

# Approach
Always pass in the DID without scheme to the DID finder. The request record in the DB should always include the scheme even if it was defaulted.

