### PR TITLE
Add finish time to dashboard; show requests in a more intuitive order

### DIFF
--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -8,7 +8,8 @@
       <tr>
         <th scope="col">Title</th>
         {% if config['ENABLE_AUTH'] %}<th scope="col">Submitted by</th>{% endif %}
-        <th scope="col">Submit time</th>
+        <th scope="col">Start time</th>
+        <th scope="col">Finish time</th>
         <th scope="col">Status</th>
         <th scope="col">Files completed</th>
         <th scope="col">Workers</th>
@@ -22,6 +23,7 @@
         </th>
         {% if config['ENABLE_AUTH'] %}<td>{{ req.submitter_name }}</td>{% endif %}
         <td>{{ req.submit_time.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+        <td>{{ req.finish_time.strftime("%Y-%m-%d %H:%M:%S") if req.finish_time else "-" }}</td>
         <td>
           <div id="status-{{ req.request_id }}">
             {{ req.status }}

--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -4,7 +4,7 @@
 
 {% macro requests_table(pagination, humanize) %}
   <table class="table table-sm table-bordered table-striped">
-    <caption>All times in UTC</caption>
+    <caption>All times in UTC.</caption>
     <thead class="thead-dark">
       <tr>
         <th scope="col">Title</th>

--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -3,7 +3,8 @@
 {% from 'bootstrap/pagination.html' import render_pagination %}
 
 {% macro requests_table(pagination, humanize) %}
-  <table class="table">
+  <table class="table table-sm table-bordered table-striped">
+    <caption>All times in UTC</caption>
     <thead class="thead-dark">
       <tr>
         <th scope="col">Title</th>

--- a/servicex/web/global_dashboard.py
+++ b/servicex/web/global_dashboard.py
@@ -9,6 +9,6 @@ from servicex.models import TransformRequest
 def global_dashboard():
     page = request.args.get('page', 1, type=int)
     pagination: Pagination = TransformRequest.query\
-        .order_by(TransformRequest.id.desc())\
+        .order_by(TransformRequest.finish_time.desc(), TransformRequest.submit_time.desc())\
         .paginate(page=page, per_page=25, error_out=False)
     return render_template("global_dashboard.html", pagination=pagination)

--- a/servicex/web/user_dashboard.py
+++ b/servicex/web/user_dashboard.py
@@ -10,6 +10,6 @@ def user_dashboard():
     page = request.args.get('page', 1, type=int)
     pagination: Pagination = TransformRequest.query\
         .filter_by(submitted_by=session["user_id"])\
-        .order_by(TransformRequest.id.desc())\
+        .order_by(TransformRequest.finish_time.desc(), TransformRequest.submit_time.desc())\
         .paginate(page=page, per_page=15, error_out=False)
     return render_template("user_dashboard.html", pagination=pagination)


### PR DESCRIPTION
This PR contains a few updates to the dashboards:
- A new column for `finish_time`
- Requests are now sorted in (`finish_time` desc, `submit_time` desc) order. This is more intuitive: any ongoing requests are shown at the top (latest first), with completed requests appearing after that (most recently completed first).
- Styles have been tweaked a bit

Fixes #114 