### PR TITLE
Update finish time on dashboard when request completes

### DIFF
--- a/servicex/resources/file_transform_status.py
+++ b/servicex/resources/file_transform_status.py
@@ -57,7 +57,6 @@ class FileTransformationStatus(ServiceXResource):
                                  info=status.info[:max_string_size])
         file_status.save_to_db()
 
-        print(file_status)
         try:
             db.session.commit()
         except Exception:

--- a/servicex/resources/transform_status.py
+++ b/servicex/resources/transform_status.py
@@ -50,14 +50,21 @@ class TransformationStatus(ServiceXResource):
 
         status_request = status_request_parser.parse_args()
 
+        # Format timestamps with military timezone, given that they are in UTC.
+        # See https://stackoverflow.com/a/42777551/8534196
+        iso_fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
         result_dict = {
             "status": transform.status,
             "request-id": request_id,
+            "submit-time": transform.submit_time.strftime(iso_fmt),
+            "finish-time": transform.finish_time,
             "files-processed": transform.files_processed,
             "files-skipped": transform.files_failed,
             "files-remaining": transform.files_remaining,
             "stats": transform.statistics
         }
+        if transform.finish_time is not None:
+            result_dict["finish-time"] = transform.finish_time.strftime(iso_fmt)
 
         if status_request.details:
             result_dict['details'] = TransformationResult.to_json_list(

--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -24,7 +24,9 @@
         </th>
         {% if config['ENABLE_AUTH'] %}<td>{{ req.submitter_name }}</td>{% endif %}
         <td>{{ req.submit_time.strftime("%Y-%m-%d %H:%M:%S") }}</td>
-        <td>{{ req.finish_time.strftime("%Y-%m-%d %H:%M:%S") if req.finish_time else "-" }}</td>
+        <td id="finish-time-{{ req.request_id }}">
+          {{ req.finish_time.strftime("%Y-%m-%d %H:%M:%S") if req.finish_time else "-" }}
+        </td>
         <td>
           <div id="status-{{ req.request_id }}">
             {{ req.status }}
@@ -100,6 +102,8 @@
               watched.delete(req_id);
               $(`#progress-${req_id}`).remove();
               $(`#replicas-${req_id}`).text("-")
+              const [d, t] = data["finish-time"].split("T")
+              $(`#finish-time-${req_id}`).text(`${d} ${t.split(".")[0]}`)
             }
           })
       }));

--- a/tests/resources/test_transform_status.py
+++ b/tests/resources/test_transform_status.py
@@ -25,6 +25,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime
+
 from tests.resource_test_base import ResourceTestBase
 
 
@@ -92,6 +94,7 @@ class TestTransformStatus(ResourceTestBase):
         servicex.models.TransformRequest.statistics = mock_statistics
 
         fake_transform_request = self._generate_transform_request()
+        fake_transform_request.finish_time = datetime.max
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
@@ -100,11 +103,12 @@ class TestTransformStatus(ResourceTestBase):
 
         response = client.get('/servicex/transformation/1234/status')
         assert response.status_code == 200
+        iso_fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
         assert response.json == {
             "status": fake_transform_request.status,
             'request-id': "1234",
-            "submit-time": fake_transform_request.submit_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            "finish-time": fake_transform_request.finish_time,
+            "submit-time": fake_transform_request.submit_time.strftime(iso_fmt),
+            "finish-time": fake_transform_request.finish_time.strftime(iso_fmt),
             'files-processed': mock_files_processed.return_value,
             'files-remaining': mock_files_remaining.return_value,
             'files-skipped': mock_files_failed.return_value,

--- a/tests/resources/test_transform_status.py
+++ b/tests/resources/test_transform_status.py
@@ -91,16 +91,20 @@ class TestTransformStatus(ResourceTestBase):
         })
         servicex.models.TransformRequest.statistics = mock_statistics
 
+        fake_transform_request = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
             'return_request',
-            return_value=self._generate_transform_request())
+            return_value=fake_transform_request
+        )
 
         response = client.get('/servicex/transformation/1234/status')
         assert response.status_code == 200
         assert response.json == {
-            "status": "Submitted",
-            'request-id': '1234',
+            "status": fake_transform_request.status,
+            'request-id': "1234",
+            "submit-time": fake_transform_request.submit_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "finish-time": fake_transform_request.finish_time,
             'files-processed': mock_files_processed.return_value,
             'files-remaining': mock_files_remaining.return_value,
             'files-skipped': mock_files_failed.return_value,


### PR DESCRIPTION
This PR makes it so that when a request completes, the AJAX callback will update the Finish Time on the dashboard, so you don't need to refresh to see when it completed.

Other small tweaks:
- Added submit time and finish time to the TransformStatus endpoint at `/servicex/transformation/<request_id>/status` in order to facilitate this change.
- Added a note that all times are in UTC

Fixes #123.