### PR TITLE
Add endpoint name to generated YAML config files

### DIFF
--- a/servicex/web/servicex_file.py
+++ b/servicex/web/servicex_file.py
@@ -28,7 +28,8 @@ def servicex_file():
     endpoint_url = get_correct_url(request)
     body = f"""\
     api_endpoints:
-      - endpoint: {endpoint_url}
+      - name: {backend_type}
+        endpoint: {endpoint_url}
         token: {user.refresh_token}
         type: {backend_type}
     """

--- a/tests/web/test_servicex_file.py
+++ b/tests/web/test_servicex_file.py
@@ -16,7 +16,8 @@ class TestServiceXFile(WebTestBase):
         response: Response = client.get(url_for('servicex-file'))
         expected = """\
         api_endpoints:
-          - endpoint: http://localhost/
+          - name: xaod
+            endpoint: http://localhost/
             token: abcdef
             type: xaod
         """


### PR DESCRIPTION
Updates the generated `servicex.yaml` config files to be compliant with the changes made in ssl-hep/ServiceX_frontend#198. The single endpoint in the generated file will now have a `name` attribute,, which currently defaults to the same value as the backend type, e.g.
```yaml
        api_endpoints:
          - name: xaod
            endpoint: http://localhost:5000/
            token: ******
            type: xaod
```