### PR TITLE
Add transformation results page

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -136,8 +136,6 @@ class TransformRequest(db.Model):
     KAFKA_DEST = 'kafka'
     VOLUME_DEST = 'volume'
 
-    _cache = {}
-
     id = db.Column(db.Integer, primary_key=True)
     request_id = db.Column(db.String(48), unique=True, nullable=False, index=True)
     title = db.Column(db.String(128), nullable=True)
@@ -195,15 +193,6 @@ class TransformRequest(db.Model):
     @classmethod
     def return_json(cls, requests: Iterable['TransformRequest']):
         return {'requests': [r.to_json() for r in requests]}
-
-    @classmethod
-    def get_request_cached(cls, request_id):
-        if request_id in TransformRequest._cache:
-            return TransformRequest._cache[request_id]
-
-        live_val = TransformRequest.lookup(request_id)
-        TransformRequest._cache[request_id] = live_val.id
-        return live_val.id
 
     @classmethod
     def lookup(cls, key: Union[str, int]) -> Optional['TransformRequest']:

--- a/servicex/resources/add_file_to_dataset.py
+++ b/servicex/resources/add_file_to_dataset.py
@@ -44,7 +44,7 @@ class AddFileToDataset(ServiceXResource):
         try:
             from servicex.models import db
             add_file_request = request.get_json()
-            submitted_request = TransformRequest.return_request(request_id)
+            submitted_request = TransformRequest.lookup(request_id)
 
             db_record = DatasetFile(request_id=request_id,
                                     file_path=add_file_request['file_path'],

--- a/servicex/resources/fileset_complete.py
+++ b/servicex/resources/fileset_complete.py
@@ -39,7 +39,7 @@ class FilesetComplete(ServiceXResource):
 
     def put(self, request_id):
         summary = request.get_json()
-        rec = TransformRequest.return_request(request_id)
+        rec = TransformRequest.lookup(request_id)
         self.lookup_result_processor.report_fileset_complete(
             rec,
             num_files=summary['files'],

--- a/servicex/resources/preflight_check.py
+++ b/servicex/resources/preflight_check.py
@@ -42,7 +42,7 @@ class PreflightCheck(ServiceXResource):
 
     def post(self, request_id):
         body = request.get_json()
-        submitted_request = TransformRequest.return_request(request_id)
+        submitted_request = TransformRequest.lookup(request_id)
 
         try:
             self.lookup_result_processor.publish_preflight_request(

--- a/servicex/resources/transform_cancel.py
+++ b/servicex/resources/transform_cancel.py
@@ -41,7 +41,7 @@ class TransformCancel(ServiceXResource):
 
     @auth_required
     def get(self, request_id: str):
-        transform_req = TransformRequest.return_request(request_id)
+        transform_req = TransformRequest.lookup(request_id)
         if not transform_req:
             msg = f'Transformation request not found with id: {request_id}'
             return {'message': msg}, 404

--- a/servicex/resources/transform_errors.py
+++ b/servicex/resources/transform_errors.py
@@ -38,7 +38,7 @@ class TransformErrors(ServiceXResource):
         Fetches errors for a given transformation request.
         :param request_id: UUID of transformation request.
         """
-        transform = TransformRequest.return_request(request_id)
+        transform = TransformRequest.lookup(request_id)
         if not transform:
             msg = f'Transformation request not found with id: {request_id}'
             return {'message': msg}, 404

--- a/servicex/resources/transform_start.py
+++ b/servicex/resources/transform_start.py
@@ -45,7 +45,7 @@ class TransformStart(ServiceXResource):
         :param request_id: UUID of transformation request.
         """
         from servicex.kafka_topic_manager import KafkaTopicManager
-        submitted_request = TransformRequest.return_request(request_id)
+        submitted_request = TransformRequest.lookup(request_id)
 
         if submitted_request.status == "Canceled":
             return {"message": "Transform request canceled by user."}, 409

--- a/servicex/resources/transform_status.py
+++ b/servicex/resources/transform_status.py
@@ -43,7 +43,7 @@ status_request_parser.add_argument('details', type=bool, default=False,
 class TransformationStatus(ServiceXResource):
     @auth_required
     def get(self, request_id):
-        transform = TransformRequest.return_request(request_id)
+        transform = TransformRequest.lookup(request_id)
         if not transform:
             msg = f'Transformation request not found with id: {request_id}'
             return {'message': msg}, 404
@@ -103,7 +103,7 @@ class TransformationStatusInternal(ServiceXResource):
             print(status.info)
             print("+--------------------------------------------+")
 
-            submitted_request = TransformRequest.return_request(request_id)
+            submitted_request = TransformRequest.lookup(request_id)
             submitted_request.status = 'Fatal'
             submitted_request.finish_time = datetime.now(tz=timezone.utc)
             submitted_request.failure_description = status.info

--- a/servicex/resources/transformation_request.py
+++ b/servicex/resources/transformation_request.py
@@ -39,7 +39,7 @@ class TransformationRequest(ServiceXResource):
     @auth_required
     def get(self, request_id):
         # Validate that the user is an admin or submitted the request
-        transform = TransformRequest.return_request(request_id)
+        transform = TransformRequest.lookup(request_id)
         if not transform:
             msg = f'Transformation request not found with id: {request_id}'
             return {'message': msg}, 404

--- a/servicex/resources/transformer_file_complete.py
+++ b/servicex/resources/transformer_file_complete.py
@@ -41,7 +41,7 @@ class TransformerFileComplete(ServiceXResource):
 
     def put(self, request_id):
         info = request.get_json()
-        transform_req = TransformRequest.return_request(request_id)
+        transform_req = TransformRequest.lookup(request_id)
         if transform_req is None:
             return {"message": f"Request not found with id: '{request_id}'"}, 404
 

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -65,6 +65,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     from servicex.web.api_token import api_token
     from servicex.web.servicex_file import servicex_file
     from servicex.web.transformation_request import transformation_request
+    from servicex.web.transformation_results import transformation_results
 
     # Must be its own module to allow patching
     from servicex.web.create_profile import create_profile
@@ -93,6 +94,11 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
         '/transformation-request/<id_>',
         'transformation_request',
         transformation_request
+    )
+    app.add_url_rule(
+        '/transformation-request/<id_>/results',
+        'transformation_results',
+        transformation_results
     )
 
     # User management and Authentication Endpoints

--- a/servicex/templates/requests_table.html
+++ b/servicex/templates/requests_table.html
@@ -41,10 +41,16 @@
         </td>
         <td>
           <div>
-            <span id="files-processed-{{ req.request_id }}">{{ humanize.intcomma(req.files_processed) }}</span> of
-            <span>{{ humanize.intcomma(req.files or "Unknown") }}</span></div>
-          <div id="files-failed-{{ req.request_id }}">
-            {% if req.files_failed %}({{ req.files_failed }} failed){% endif %}
+            <a id="files-processed-{{ req.request_id }}"
+               href="/transformation-request/{{ req.id }}/results?status=success">
+              {{ humanize.intcomma(req.files_processed) }}
+            </a> of
+            <span>{{ humanize.intcomma(req.files or "Unknown") }}</span>
+          </div>
+          <div {% if not req.files_failed %}style="display: none"{% endif %}
+              id="files-failed-wrapper-{{ req.request_id }}">
+              (<a id="files-failed-{{ req.request_id }}"
+                 href="/transformation-request/{{ req.id }}/results?status=failure">{{ req.files_failed }}</a> failed)
           </div>
         </td>
         <td id="replicas-{{ req.request_id }}">-</td>
@@ -107,7 +113,8 @@
             progressBar.css("width", `${progress}%`);
             if (failed > 0) {
               progressBar.addClass("bg-warning");
-              $(`#files-failed-${req_id}`).text(`(${failed} failed)`);
+              $(`#files-failed-wrapper-${req_id}`).show();
+              $(`#files-failed-${req_id}`).text(failed);
             }
             if (status === "Complete" || status === "Fatal" || status === "Canceled") {
               watched.delete(req_id);

--- a/servicex/templates/transformation_results.html
+++ b/servicex/templates/transformation_results.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% from 'bootstrap/table.html' import render_table %}
+{% from 'bootstrap/pagination.html' import render_pager %}
+{% from 'bootstrap/pagination.html' import render_pagination %}
+
+{% block content %}
+  <div>
+    <div class="content-section">
+      <h4 class="mb-3">
+        Results for Transformation
+        <a href="/transformation-request/{{ treq.request_id }}">{{ treq.request_id }}</a>
+      </h4>
+      <table class="table table-sm table-bordered table-striped">
+        <thead class="thead-dark">
+          <tr>
+            <th scope="col">ID</th>
+            <th scope="col">File Path</th>
+            <th scope="col">Status</th>
+            <th scope="col">Time</th>
+            <th scope="col">Events</th>
+            <th scope="col">Bytes</th>
+            <th scope="col">Rate</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for res in pagination.items %}
+          <tr>
+            <th scope="row">{{ res.file_id }}</th>
+            <td style="word-break: break-all">{{ res.file_path }}</td>
+            <td>{{ res.transform_status }}</td>
+            <td>{{ res.transform_time }}</td>
+            <td>{{ res.total_events }}</td>
+            <td>{{ res.total_bytes }}</td>
+            <td>{{ res.avg_rate }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      {% if pagination.items %}
+        {{ render_pagination(pagination, align='center') }}
+      {% else %}
+        <div>No results found!</div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/servicex/web/transformation_request.py
+++ b/servicex/web/transformation_request.py
@@ -6,10 +6,7 @@ from servicex.models import TransformRequest
 
 @oauth_required
 def transformation_request(id_: str):
-    if id_.isnumeric():
-        req = TransformRequest.query.get(id_)
-    else:
-        req = TransformRequest.query.filter_by(request_id=id_).one()
+    req = TransformRequest.lookup(id_)
     if not req:
         abort(404)
     return render_template('transformation_request.html', req=req)

--- a/servicex/web/transformation_results.py
+++ b/servicex/web/transformation_results.py
@@ -1,0 +1,24 @@
+from flask import render_template, request, abort
+from flask_sqlalchemy import Pagination
+
+from servicex.decorators import oauth_required
+from servicex.models import TransformRequest, TransformationResult
+
+
+@oauth_required
+def transformation_results(id_: str):
+    if id_.isnumeric():
+        treq = TransformRequest.query.get(id_)
+    else:
+        treq = TransformRequest.query.filter_by(request_id=id_).one()
+    if not treq:
+        abort(404)
+    page = request.args.get('page', 1, type=int)
+    filter_by_values = {}
+    if status := request.args.get("status"):
+        filter_by_values["transform_status"] = status
+    pagination: Pagination = TransformationResult.query\
+        .filter_by(request_id=treq.request_id, **filter_by_values)\
+        .order_by(TransformationResult.file_id.asc())\
+        .paginate(page=page, per_page=100, error_out=False)
+    return render_template("transformation_results.html", treq=treq, pagination=pagination)

--- a/servicex/web/transformation_results.py
+++ b/servicex/web/transformation_results.py
@@ -15,7 +15,8 @@ def transformation_results(id_: str):
         abort(404)
     page = request.args.get('page', 1, type=int)
     filter_by_values = {}
-    if status := request.args.get("status"):
+    status = request.args.get("status")
+    if status:
         filter_by_values["transform_status"] = status
     pagination: Pagination = TransformationResult.query\
         .filter_by(request_id=treq.request_id, **filter_by_values)\

--- a/servicex/web/transformation_results.py
+++ b/servicex/web/transformation_results.py
@@ -7,10 +7,7 @@ from servicex.models import TransformRequest, TransformationResult
 
 @oauth_required
 def transformation_results(id_: str):
-    if id_.isnumeric():
-        treq = TransformRequest.query.get(id_)
-    else:
-        treq = TransformRequest.query.filter_by(request_id=id_).one()
+    treq = TransformRequest.lookup(id_)
     if not treq:
         abort(404)
     page = request.args.get('page', 1, type=int)

--- a/tests/resources/test_add_file_to_dataset.py
+++ b/tests/resources/test_add_file_to_dataset.py
@@ -38,7 +38,7 @@ class TestAddFileToDataset(ResourceTestBase):
         import servicex
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=self._generate_transform_request())
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
@@ -70,7 +70,7 @@ class TestAddFileToDataset(ResourceTestBase):
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=root_file_transform_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
@@ -97,7 +97,7 @@ class TestAddFileToDataset(ResourceTestBase):
         import servicex
         mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=self._generate_transform_request())
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)

--- a/tests/resources/test_fileset_complete.py
+++ b/tests/resources/test_fileset_complete.py
@@ -35,7 +35,7 @@ class TestFilesetComplete(ResourceTestBase):
         submitted_request = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=submitted_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)

--- a/tests/resources/test_preflight_check.py
+++ b/tests/resources/test_preflight_check.py
@@ -36,7 +36,7 @@ class TestPreflightCheck(ResourceTestBase):
         submitted_request = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=submitted_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
@@ -64,7 +64,7 @@ class TestPreflightCheck(ResourceTestBase):
 
         mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=submitted_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)

--- a/tests/resources/test_submit_transformation_request.py
+++ b/tests/resources/test_submit_transformation_request.py
@@ -114,7 +114,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         assert response.status_code == 200
         request_id = response.json['request_id']
         with client.application.app_context():
-            saved_obj = TransformRequest.return_request(request_id)
+            saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
             assert saved_obj.did == 'rucio://123-45-678'
             assert saved_obj.finish_time is None
@@ -166,7 +166,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         assert response.status_code == 200
         request_id = response.json['request_id']
         with client.application.app_context():
-            saved_obj = TransformRequest.return_request(request_id)
+            saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
             assert saved_obj.did == 'rucio://123-45-678'
 
@@ -199,7 +199,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         request_id = response.json['request_id']
 
         with client.application.app_context():
-            saved_obj = TransformRequest.return_request(request_id)
+            saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
             assert saved_obj.did == 'rucio://123-45-678'
             assert saved_obj.request_id == request_id
@@ -336,7 +336,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
         mock_object_store.create_bucket.assert_called_with(request_id)
         with client.application.app_context():
-            saved_obj = TransformRequest.return_request(request_id)
+            saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
             assert saved_obj.result_destination == 'object-store'
             assert saved_obj.result_format == 'parquet'
@@ -351,7 +351,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         request_id = response.json['request_id']
 
         with client.application.app_context():
-            saved_obj = TransformRequest.return_request(request_id)
+            saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
             assert saved_obj.submitted_by == mock_requesting_user.id
 
@@ -362,6 +362,6 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         assert response.status_code == 200
         request_id = response.json['request_id']
         with client.application.app_context():
-            saved_obj = TransformRequest.return_request(request_id)
+            saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
             assert saved_obj.title == title

--- a/tests/resources/test_transform_cancel.py
+++ b/tests/resources/test_transform_cancel.py
@@ -20,7 +20,7 @@ class TestTransformCancel(ResourceTestBase):
         mock_transform_request_cls = mocker.patch(f"{self.module}.TransformRequest")
         fake_transform = self._generate_transform_request()
         fake_transform.save_to_db = mocker.Mock()
-        mock_transform_request_cls.return_request.return_value = fake_transform
+        mock_transform_request_cls.lookup.return_value = fake_transform
         return fake_transform
 
     def test_submitted(self, client, mock_manager, fake_transform):

--- a/tests/resources/test_transform_errors.py
+++ b/tests/resources/test_transform_errors.py
@@ -35,7 +35,7 @@ class TestTransformErrors(ResourceTestBase):
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=self._generate_transform_request())
 
         file_error_result = [
@@ -70,7 +70,7 @@ class TestTransformErrors(ResourceTestBase):
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=None)
 
         response = client.get('/servicex/transformation/1234/errors')

--- a/tests/resources/test_transform_file_complete.py
+++ b/tests/resources/test_transform_file_complete.py
@@ -49,7 +49,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
         fake_req = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest, 'return_request', return_value=fake_req
+            servicex.models.TransformRequest, 'lookup', return_value=fake_req
         )
 
         mock_files_remaining = mocker.PropertyMock(return_value=1)
@@ -73,7 +73,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
         fake_req = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest, 'return_request', return_value=fake_req
+            servicex.models.TransformRequest, 'lookup', return_value=fake_req
         )
 
         mock_files_remaining = mocker.PropertyMock(return_value=None)
@@ -97,7 +97,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
         fake_req = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest, 'return_request', return_value=fake_req
+            servicex.models.TransformRequest, 'lookup', return_value=fake_req
         )
 
         mock_files_remaining = mocker.PropertyMock(return_value=0)
@@ -123,7 +123,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=None
         )
 
@@ -151,7 +151,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
         mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=self._generate_transform_request())
 
         mock_files_remaining = mocker.PropertyMock(return_value=1)
@@ -181,7 +181,7 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
         mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=self._generate_transform_request())
 
         mock_files_remaining = mocker.PropertyMock(return_value=0)

--- a/tests/resources/test_transform_start.py
+++ b/tests/resources/test_transform_start.py
@@ -38,7 +38,7 @@ class TestTransformationStart(ResourceTestBase):
         mock_request.save_to_db = mocker.Mock()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=mock_request)
 
         from servicex.kafka_topic_manager import KafkaTopicManager
@@ -96,7 +96,7 @@ class TestTransformationStart(ResourceTestBase):
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=mock_request)
 
         client = self._test_client(
@@ -126,7 +126,7 @@ class TestTransformationStart(ResourceTestBase):
         mock_request.save_to_db = mocker.Mock()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=mock_request)
 
         mock_request.status = "Canceled"

--- a/tests/resources/test_transform_status.py
+++ b/tests/resources/test_transform_status.py
@@ -37,7 +37,7 @@ class TestTransformStatus(ResourceTestBase):
         mock_request.save_to_db = mocker.Mock()
         mocker.patch.object(
             TransformRequest,
-            'return_request',
+            'lookup',
             return_value=mock_request)
 
         response = client.post('/servicex/internal/transformation/1234/status',
@@ -56,7 +56,7 @@ class TestTransformStatus(ResourceTestBase):
         mock_request.save_to_db = mocker.Mock()
         mocker.patch.object(
             TransformRequest,
-            'return_request',
+            'lookup',
             return_value=mock_request)
 
         response = client.post('/servicex/internal/transformation/1234/status',
@@ -97,7 +97,7 @@ class TestTransformStatus(ResourceTestBase):
         fake_transform_request.finish_time = datetime.max
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=fake_transform_request
         )
 
@@ -126,7 +126,7 @@ class TestTransformStatus(ResourceTestBase):
 
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=None)
 
         response = client.get('/servicex/transformation/1234/status')

--- a/tests/resources/test_transformation_request.py
+++ b/tests/resources/test_transformation_request.py
@@ -7,7 +7,7 @@ class TestTransformationRequest(ResourceTestBase):
         import servicex
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=self._generate_transform_request())
         client = self._test_client(extra_config={'OBJECT_STORE_ENABLED': False})
         response = client.get('/servicex/transformation/1234')
@@ -35,7 +35,7 @@ class TestTransformationRequest(ResourceTestBase):
         object_store_transform_request.result_destination = 'object-store'
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=object_store_transform_request)
 
         local_config = {
@@ -78,7 +78,7 @@ class TestTransformationRequest(ResourceTestBase):
         kafka_transform_request.result_destination = 'kafka'
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
-            'return_request',
+            'lookup',
             return_value=kafka_transform_request)
 
         local_config = {
@@ -112,7 +112,7 @@ class TestTransformationRequest(ResourceTestBase):
     def test_get_single_request_404(self, mocker, client):
         import servicex
         mock_transform_request_read = mocker.patch.object(
-            servicex.models.TransformRequest, 'return_request',
+            servicex.models.TransformRequest, 'lookup',
             return_value=None)
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 404

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -113,7 +113,7 @@ class TestDecorators(WebTestBase):
         fake_transform_id = 123
         data = {'id': fake_transform_id}
         mock = mocker.patch('servicex.resources.transformation_request'
-                            '.TransformRequest.return_request').return_value
+                            '.TransformRequest.lookup').return_value
         mock.to_json.return_value = data
         with client.application.app_context():
             response: Response = client.get(f'servicex/transformation/{fake_transform_id}')
@@ -151,7 +151,7 @@ class TestDecorators(WebTestBase):
         fake_transform_id = 123
         data = {'id': fake_transform_id}
         mock = mocker.patch('servicex.resources.transformation_request'
-                            '.TransformRequest.return_request').return_value
+                            '.TransformRequest.lookup').return_value
         mock.submitted_by = user.id
         mock.to_json.return_value = data
         with client.application.app_context():
@@ -166,7 +166,7 @@ class TestDecorators(WebTestBase):
         fake_transform_id = 123
         data = {'id': fake_transform_id}
         mock = mocker.patch('servicex.resources.transformation_request'
-                            '.TransformRequest.return_request').return_value
+                            '.TransformRequest.lookup').return_value
         mock.submitted_by = user.id
         mock.to_json.return_value = data
         with client.session_transaction() as sess:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,6 +117,8 @@ class TestTransformRequest:
         mock_query.get.return_value = expected
         result = TransformRequest.lookup(expected.id)
         assert result == expected
+        mock_query.get.assert_called_once_with(expected.id)
+        mock_query.filter_by.assert_not_called()
 
     @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
     def test_lookup_by_id_as_str(self, query_property_getter_mock):
@@ -125,6 +127,8 @@ class TestTransformRequest:
         mock_query.get.return_value = expected
         result = TransformRequest.lookup(str(expected.id))
         assert result == expected
+        mock_query.get.assert_called_once_with(str(expected.id))
+        mock_query.filter_by.assert_not_called()
 
     @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
     def test_lookup_by_request_id(self, query_property_getter_mock):
@@ -133,6 +137,9 @@ class TestTransformRequest:
         mock_query.filter_by.return_value.one.return_value = expected
         result = TransformRequest.lookup(expected.request_id)
         assert result == expected
+        mock_query.filter_by.assert_called_once_with(request_id=expected.request_id)
+        mock_query.filter_by.return_value.one.assert_called_once()
+        mock_query.get.assert_not_called()
 
     @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
     def test_lookup_not_found(self, query_property_getter_mock):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,18 +1,23 @@
+import unittest.mock
 from datetime import datetime, timedelta
 
+import sqlalchemy as sqla
 from pytest import fixture
 
 from servicex.models import UserModel, TransformRequest, TransformationResult
 
 
 class TestTransformRequest:
+    @fixture
+    def mock_result_cls(self, mocker):
+        mock_result_cls = mocker.patch("servicex.models.TransformationResult")
+        mock_query = mocker.MagicMock()
+        mock_result_cls.query.filter_by.return_value = mock_query
+        return mock_result_cls
 
     @fixture
-    def mock_tr(self, mocker):
-        mock_tr = mocker.patch("servicex.models.TransformationResult")
-        mock_query = mocker.MagicMock()
-        mock_tr.query.filter_by.return_value = mock_query
-        return mock_tr
+    def mock_query(self, mocker):
+        return TransformRequest.query
 
     def test_age(self, mocker):
         request = TransformRequest()
@@ -57,20 +62,20 @@ class TestTransformRequest:
         request = TransformRequest()
         assert request.submitter_name is None
 
-    def test_result_count(self, mock_tr):
-        mock_tr.query.filter_by.return_value.count.return_value = 3
+    def test_result_count(self, mock_result_cls):
+        mock_result_cls.query.filter_by.return_value.count.return_value = 3
         request = TransformRequest(request_id="1234")
         assert request.result_count == 3
-        mock_tr.query.filter_by.assert_called_once_with(request_id=request.request_id)
-        mock_tr.query.filter_by.return_value.count.assert_called_once()
+        mock_result_cls.query.filter_by.assert_called_once_with(request_id=request.request_id)
+        mock_result_cls.query.filter_by.return_value.count.assert_called_once()
 
-    def test_results(self, mock_tr):
+    def test_results(self, mock_result_cls):
         results = [TransformationResult(), TransformationResult()]
-        mock_tr.query.filter_by.return_value.all.return_value = results
+        mock_result_cls.query.filter_by.return_value.all.return_value = results
         request = TransformRequest(request_id="1234")
         assert request.results == results
-        mock_tr.query.filter_by.assert_called_once_with(request_id=request.request_id)
-        mock_tr.query.filter_by.return_value.all.assert_called_once()
+        mock_result_cls.query.filter_by.assert_called_once_with(request_id=request.request_id)
+        mock_result_cls.query.filter_by.return_value.all.assert_called_once()
 
     def test_files_remaining(self, mocker):
         request = TransformRequest()
@@ -87,20 +92,51 @@ class TestTransformRequest:
         request.files = None
         assert request.files_remaining is None
 
-    def test_files_processed(self, mock_tr):
-        mock_tr.query.filter_by.return_value.count.return_value = 3
+    def test_files_processed(self, mock_result_cls):
+        mock_result_cls.query.filter_by.return_value.count.return_value = 3
         request = TransformRequest(request_id="1234")
         assert request.files_processed == 3
-        mock_tr.query.filter_by.assert_called_once_with(
+        mock_result_cls.query.filter_by.assert_called_once_with(
             request_id=request.request_id, transform_status="success"
         )
-        mock_tr.query.filter_by.return_value.count.assert_called_once()
+        mock_result_cls.query.filter_by.return_value.count.assert_called_once()
 
-    def test_files_failed(self, mock_tr):
-        mock_tr.query.filter_by.return_value.count.return_value = 3
+    def test_files_failed(self, mock_result_cls):
+        mock_result_cls.query.filter_by.return_value.count.return_value = 3
         request = TransformRequest(request_id="1234")
         assert request.files_failed == 3
-        mock_tr.query.filter_by.assert_called_once_with(
+        mock_result_cls.query.filter_by.assert_called_once_with(
             request_id=request.request_id, transform_status="failure"
         )
-        mock_tr.query.filter_by.return_value.count.assert_called_once()
+        mock_result_cls.query.filter_by.return_value.count.assert_called_once()
+
+    @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
+    def test_lookup_by_id(self, query_property_getter_mock):
+        mock_query = query_property_getter_mock.return_value
+        expected = TransformRequest(id=17, request_id="445a9533-edec-4017-a542-86d17d5c166f")
+        mock_query.get.return_value = expected
+        result = TransformRequest.lookup(expected.id)
+        assert result == expected
+
+    @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
+    def test_lookup_by_id_as_str(self, query_property_getter_mock):
+        mock_query = query_property_getter_mock.return_value
+        expected = TransformRequest(id=17, request_id="445a9533-edec-4017-a542-86d17d5c166f")
+        mock_query.get.return_value = expected
+        result = TransformRequest.lookup(str(expected.id))
+        assert result == expected
+
+    @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
+    def test_lookup_by_request_id(self, query_property_getter_mock):
+        mock_query = query_property_getter_mock.return_value
+        expected = TransformRequest(id=17, request_id="445a9533-edec-4017-a542-86d17d5c166f")
+        mock_query.filter_by.return_value.one.return_value = expected
+        result = TransformRequest.lookup(expected.request_id)
+        assert result == expected
+
+    @unittest.mock.patch('flask_sqlalchemy._QueryProperty.__get__')
+    def test_lookup_not_found(self, query_property_getter_mock):
+        mock_query = query_property_getter_mock.return_value
+        mock_query.get.side_effect = sqla.orm.exc.NoResultFound
+        result = TransformRequest.lookup(12)
+        assert result is None

--- a/tests/web/test_transformation_results.py
+++ b/tests/web/test_transformation_results.py
@@ -12,19 +12,19 @@ statuses = ["success", "failure"]
 
 
 class TestUserDashboard(WebTestBase):
+    endpoint = "transformation_results"
     module = "servicex.web.transformation_results"
+    template_name = 'transformation_results.html'
 
     @pytest.fixture
-    def mock_treq(self, mocker) -> TransformRequest:
-        mock_cls = mocker.patch(f"{self.module}.TransformRequest")
-        req = self._test_transformation_req()
-        mock_cls.query.get.return_value = req
-        mock_cls.query.filter_by.return_value.one.return_value = req
-        return req
-
-    @pytest.fixture
-    def mock_treq_cls(self, mocker):
+    def mock_tr_cls(self, mocker):
         return mocker.patch(f"{self.module}.TransformRequest")
+
+    @pytest.fixture
+    def mock_tr(self, mock_tr_cls) -> TransformRequest:
+        req = self._test_transformation_req()
+        mock_tr_cls.lookup.return_value = req
+        return req
 
     @pytest.fixture
     def mock_result_cls(self, mocker):
@@ -34,38 +34,38 @@ class TestUserDashboard(WebTestBase):
         results = [TransformationResult(transform_status=status) for status in statuses]
         return results
 
-    def test_get_empty_state(self, client, mock_treq, mock_result_cls, captured_templates):
+    def test_get_empty_state(self, client, mock_tr, mock_result_cls, captured_templates):
         mock_result_query = mock_result_cls.query.filter_by.return_value.order_by.return_value
         pagination = Pagination(mock_result_query, page=1, per_page=100, total=0, items=[])
         mock_result_query.paginate.return_value = pagination
-        response: Response = client.get(url_for('transformation_results', id_=mock_treq.id))
+        response: Response = client.get(url_for(self.endpoint, id_=mock_tr.id))
         assert response.status_code == 200
-        mock_result_cls.query.filter_by.assert_called_once_with(request_id=mock_treq.request_id)
+        mock_result_cls.query.filter_by.assert_called_once_with(request_id=mock_tr.request_id)
         template, context = captured_templates[0]
-        assert template.name == 'transformation_results.html'
+        assert template.name == self.template_name
         assert context["pagination"] == pagination
 
     @pytest.mark.parametrize("status", [None, *statuses])
     def test_get_with_results(
-        self, client, mock_treq, mock_result_cls, status, captured_templates
+        self, client, mock_tr, mock_result_cls, status, captured_templates
     ):
         mock_result_query = mock_result_cls.query.filter_by.return_value.order_by.return_value
         items = [r for r in self._fake_transformation_results() if r.transform_status == status]
         pagination = Pagination(mock_result_query, page=1, per_page=100, total=0, items=items)
         mock_result_query.paginate.return_value = pagination
         query_params = {"status": status} if status is not None else {}
-        url = url_for('transformation_results', id_=mock_treq.id, **query_params)
+        url = url_for(self.endpoint, id_=mock_tr.id, **query_params)
         response: Response = client.get(url)
         assert response.status_code == 200
         query_kwargs = {"transform_status": status} if status is not None else {}
         mock_result_cls.query.filter_by.assert_called_once_with(
-            request_id=mock_treq.request_id, **query_kwargs
+            request_id=mock_tr.request_id, **query_kwargs
         )
         template, context = captured_templates[0]
-        assert template.name == 'transformation_results.html'
+        assert template.name == self.template_name
         assert context["pagination"] == pagination
 
-    def test_404(self, client, mock_treq_cls):
-        mock_treq_cls.query.get.return_value = None
-        resp: Response = client.get(url_for('transformation_results', id_=1))
+    def test_404(self, client, mock_tr_cls):
+        mock_tr_cls.lookup.return_value = None
+        resp: Response = client.get(url_for(self.endpoint, id_=1))
         assert resp.status_code == 404

--- a/tests/web/test_transformation_results.py
+++ b/tests/web/test_transformation_results.py
@@ -1,0 +1,71 @@
+from typing import List
+
+from flask import Response, url_for
+from flask_sqlalchemy import Pagination
+
+import pytest
+
+from servicex.models import TransformRequest, TransformationResult
+from .web_test_base import WebTestBase
+
+statuses = ["success", "failure"]
+
+
+class TestUserDashboard(WebTestBase):
+    module = "servicex.web.transformation_results"
+
+    @pytest.fixture
+    def mock_treq(self, mocker) -> TransformRequest:
+        mock_cls = mocker.patch(f"{self.module}.TransformRequest")
+        req = self._test_transformation_req()
+        mock_cls.query.get.return_value = req
+        mock_cls.query.filter_by.return_value.one.return_value = req
+        return req
+
+    @pytest.fixture
+    def mock_treq_cls(self, mocker):
+        return mocker.patch(f"{self.module}.TransformRequest")
+
+    @pytest.fixture
+    def mock_result_cls(self, mocker):
+        return mocker.patch(f"{self.module}.TransformationResult")
+
+    def _fake_transformation_results(self) -> List[TransformationResult]:
+        results = [TransformationResult(transform_status=status) for status in statuses]
+        return results
+
+    def test_get_empty_state(self, client, mock_treq, mock_result_cls, captured_templates):
+        mock_result_query = mock_result_cls.query.filter_by.return_value.order_by.return_value
+        pagination = Pagination(mock_result_query, page=1, per_page=100, total=0, items=[])
+        mock_result_query.paginate.return_value = pagination
+        response: Response = client.get(url_for('transformation_results', id_=mock_treq.id))
+        assert response.status_code == 200
+        mock_result_cls.query.filter_by.assert_called_once_with(request_id=mock_treq.request_id)
+        template, context = captured_templates[0]
+        assert template.name == 'transformation_results.html'
+        assert context["pagination"] == pagination
+
+    @pytest.mark.parametrize("status", [None, *statuses])
+    def test_get_with_results(
+        self, client, mock_treq, mock_result_cls, status, captured_templates
+    ):
+        mock_result_query = mock_result_cls.query.filter_by.return_value.order_by.return_value
+        items = [r for r in self._fake_transformation_results() if r.transform_status == status]
+        pagination = Pagination(mock_result_query, page=1, per_page=100, total=0, items=items)
+        mock_result_query.paginate.return_value = pagination
+        query_params = {"status": status} if status is not None else {}
+        url = url_for('transformation_results', id_=mock_treq.id, **query_params)
+        response: Response = client.get(url)
+        assert response.status_code == 200
+        query_kwargs = {"transform_status": status} if status is not None else {}
+        mock_result_cls.query.filter_by.assert_called_once_with(
+            request_id=mock_treq.request_id, **query_kwargs
+        )
+        template, context = captured_templates[0]
+        assert template.name == 'transformation_results.html'
+        assert context["pagination"] == pagination
+
+    def test_404(self, client, mock_treq_cls):
+        mock_treq_cls.query.get.return_value = None
+        resp: Response = client.get(url_for('transformation_request', id_=1))
+        assert resp.status_code == 404

--- a/tests/web/test_transformation_results.py
+++ b/tests/web/test_transformation_results.py
@@ -67,5 +67,5 @@ class TestUserDashboard(WebTestBase):
 
     def test_404(self, client, mock_treq_cls):
         mock_treq_cls.query.get.return_value = None
-        resp: Response = client.get(url_for('transformation_request', id_=1))
+        resp: Response = client.get(url_for('transformation_results', id_=1))
         assert resp.status_code == 404


### PR DESCRIPTION
This PR adds a new webpage at `/transformation-request/<request_id>/results` which displays records from the `transform_result` table in the database for the given transformation request.

Results are paginated (100 per page). The `status` query parameter can be used to restrict results to only successes or failures, e.g. `/transformation-request/<request_id>/results?status=failure`.

These pages are linked from the main dashboard. Additional links can be added as desired.

To reduce code duplication, the `TransformRequest.return_request` method was renamed to `TransformRequest.lookup` and refactored to take a single `key` argument which can be either a numeric ID (primary key in the database) or a UUID (`request_id` column in the database).

![image](https://user-images.githubusercontent.com/5485577/133722424-69d57d04-e8e6-4596-af36-f603983266c6.png)
