### PR TITLE
add priorityClassName config to transfomer pod spec

### DIFF
--- a/app.conf.template
+++ b/app.conf.template
@@ -34,8 +34,8 @@ TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:leftfoot1@host.docker.internal:30672/%2F
 RABBIT_RETRIES = 12
 RABBIT_RETRY_INTERVAL = 10
 
-#empty string means not setting the priorityclass, pods will get the global default if cluster has that
-TRANSFORMER_PRIORITY_CLASS = ''
+# With the default None value, pods will get the global default if cluster has such priorityclass defined
+TRANSFORMER_PRIORITY_CLASS = None
 
 # This will be mounted into the transformer pod's /data directory
 TRANSFORMER_LOCAL_PATH="/Users/bengal1/dev/IRIS-HEP/data"

--- a/app.conf.template
+++ b/app.conf.template
@@ -34,6 +34,8 @@ TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:leftfoot1@host.docker.internal:30672/%2F
 RABBIT_RETRIES = 12
 RABBIT_RETRY_INTERVAL = 10
 
+#empty string means not setting the priorityclass, pods will get the global default if cluster has that
+TRANSFORMER_PRIORITY_CLASS = ''
 
 # This will be mounted into the transformer pod's /data directory
 TRANSFORMER_LOCAL_PATH="/Users/bengal1/dev/IRIS-HEP/data"

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -155,6 +155,7 @@ class TransformerManager:
             metadata=client.V1ObjectMeta(labels={'app': "transformer-" + request_id}),
             spec=client.V1PodSpec(
                 restart_policy="Always",
+                priority_class_name=current_app.config.get('TRANSFORMER_PRIORITY_CLASS'),
                 containers=[container],
                 volumes=volumes))
 

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -150,15 +150,12 @@ class TransformerManager:
             resources=resources
         )
 
-        priority_class_name=current_app.config.get('TRANSFORMER_PRIORITY_CLASS')
-        if not priority_class_name:
-            priority_class_name = None
         # Create and Configure a spec section
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(labels={'app': "transformer-" + request_id}),
             spec=client.V1PodSpec(
                 restart_policy="Always",
-                priority_class_name=priority_class_name,
+                priority_class_name=current_app.config.get('TRANSFORMER_PRIORITY_CLASS', None),
                 containers=[container],
                 volumes=volumes))
 

--- a/servicex/transformer_manager.py
+++ b/servicex/transformer_manager.py
@@ -150,12 +150,15 @@ class TransformerManager:
             resources=resources
         )
 
+        priority_class_name=current_app.config.get('TRANSFORMER_PRIORITY_CLASS')
+        if not priority_class_name:
+            priority_class_name = None
         # Create and Configure a spec section
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(labels={'app': "transformer-" + request_id}),
             spec=client.V1PodSpec(
                 restart_policy="Always",
-                priority_class_name=current_app.config.get('TRANSFORMER_PRIORITY_CLASS'),
+                priority_class_name=priority_class_name,
                 containers=[container],
                 volumes=volumes))
 


### PR DESCRIPTION
transformer pods are big resource consumers and allow setting priorityClass is important. If no value is supplied, then pods will get a default priorityClass if the cluster has one configured.