### PR TITLE
Sortable dashboards

### DIFF
--- a/servicex/templates/global_dashboard.html
+++ b/servicex/templates/global_dashboard.html
@@ -6,7 +6,21 @@
 
   <div>
     <div class="content-section">
-      <h4 class="mb-3">Transformation Requests</h4>
+      <div class="row justify-content-between align-items-center">
+        <h4 class="mb-3 col-auto">Transformation Requests</h4>
+        <div class="dropdown col-auto">
+          <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton"
+                  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Sort: <b>{{ active_sort.title() }} ({{ active_order }})</b>
+          </button>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+              {% for sort, order in dropdown_options %}
+                <a href="?sort={{ sort }}&order={{ order }}" class="dropdown-item">{{ sort.title() }} ({{ order }})</a>
+              {% endfor %}
+          </div>
+        </div>
+      </div>
+
       {{ requests_table(pagination, humanize) }}
     </div>
   </div>

--- a/servicex/templates/global_dashboard.html
+++ b/servicex/templates/global_dashboard.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% from 'requests_table.html' import requests_table, requests_table_update_script %}
+{% from 'sort_dropdown.html' import sort_dropdown %}
 
 {% block content %}
 
@@ -8,19 +9,8 @@
     <div class="content-section">
       <div class="row justify-content-between align-items-center">
         <h4 class="mb-3 col-auto">Transformation Requests</h4>
-        <div class="dropdown col-auto">
-          <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton"
-                  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Sort: <b>{{ active_sort.title() }} ({{ active_order }})</b>
-          </button>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-              {% for sort, order in dropdown_options %}
-                <a href="?sort={{ sort }}&order={{ order }}" class="dropdown-item">{{ sort.title() }} ({{ order }})</a>
-              {% endfor %}
-          </div>
-        </div>
+        {{ sort_dropdown(dropdown_options, active_sort, active_order) }}
       </div>
-
       {{ requests_table(pagination, humanize) }}
     </div>
   </div>

--- a/servicex/templates/sort_dropdown.html
+++ b/servicex/templates/sort_dropdown.html
@@ -1,0 +1,13 @@
+{% macro sort_dropdown(options, active_sort, active_order) %}
+  <div class="dropdown col-auto">
+    <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton"
+            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Sort: <b>{{ active_sort.title() }} ({{ active_order }})</b>
+    </button>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        {% for sort, order in options %}
+          <a href="?sort={{ sort }}&order={{ order }}" class="dropdown-item">{{ sort.title() }} ({{ order }})</a>
+        {% endfor %}
+    </div>
+  </div>
+{% endmacro %}

--- a/servicex/templates/sort_dropdown.html
+++ b/servicex/templates/sort_dropdown.html
@@ -1,6 +1,6 @@
 {% macro sort_dropdown(options, active_sort, active_order) %}
   <div class="dropdown col-auto">
-    <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton"
+    <button class="btn btn-sm btn-dark dropdown-toggle" type="button" id="dropdownMenuButton"
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       Sort: <b>{{ active_sort.title() }} ({{ active_order }})</b>
     </button>

--- a/servicex/templates/user_dashboard.html
+++ b/servicex/templates/user_dashboard.html
@@ -1,6 +1,7 @@
 {% extends "authenticated-base.html" %}
 
 {% from 'requests_table.html' import requests_table, requests_table_update_script %}
+{% from 'sort_dropdown.html' import sort_dropdown %}
 
 {% block content %}
 
@@ -12,7 +13,10 @@
     </div>
 
     <div class="content-section">
-      <h4 class="mb-3">Transformation Requests</h4>
+      <div class="row justify-content-between align-items-center">
+        <h4 class="mb-3 col-auto">Transformation Requests</h4>
+        {{ sort_dropdown(dropdown_options, active_sort, active_order) }}
+      </div>
       {{ requests_table(pagination, humanize) }}
     </div>
   </div>

--- a/servicex/web/dashboard.py
+++ b/servicex/web/dashboard.py
@@ -37,7 +37,7 @@ def dashboard(template_name: str, user_specific=False):
         query = query.filter_by(submitted_by=session["user_id"])
     pagination: Pagination = query \
         .order_by(getattr(model_attributes[sort], order)()) \
-        .paginate(page=page, per_page=25, error_out=False)
+        .paginate(page=page, per_page=15, error_out=False)
     return render_template(
         template_name,
         pagination=pagination,

--- a/servicex/web/dashboard.py
+++ b/servicex/web/dashboard.py
@@ -1,0 +1,47 @@
+import itertools
+
+from flask import render_template, request, session
+from flask_restful import reqparse
+from flask_sqlalchemy import Pagination
+
+from servicex.models import TransformRequest
+
+model_attributes = {
+    "start": TransformRequest.submit_time,
+    "finish": TransformRequest.finish_time,
+    "status": TransformRequest.status
+}
+parser = reqparse.RequestParser()
+sort_choices = tuple(model_attributes.keys())
+parser.add_argument(
+    "sort",
+    choices=sort_choices,
+    default="finish",
+    help=f"Sort must be one of: {', '.join(map(repr, sort_choices))}."
+)
+order_choices = ("asc", "desc")
+parser.add_argument(
+    "order",
+    choices=order_choices,
+    default="desc",
+    help="Order must be 'asc' or 'desc'."
+)
+
+
+def dashboard(template_name: str, user_specific=False):
+    page = request.args.get('page', default=1, type=int)
+    args = parser.parse_args()
+    sort, order = args["sort"], args["order"]
+    query = TransformRequest.query
+    if user_specific:
+        query = query.filter_by(submitted_by=session["user_id"])
+    pagination: Pagination = query \
+        .order_by(getattr(model_attributes[sort], order)()) \
+        .paginate(page=page, per_page=25, error_out=False)
+    return render_template(
+        template_name,
+        pagination=pagination,
+        dropdown_options=list(itertools.product(sort_choices, order_choices)),
+        active_sort=sort,
+        active_order=order
+    )

--- a/servicex/web/dashboard.py
+++ b/servicex/web/dashboard.py
@@ -1,6 +1,6 @@
 import itertools
 
-from flask import render_template, request, session
+from flask import render_template, session
 from flask_restful import reqparse
 from flask_sqlalchemy import Pagination
 
@@ -12,6 +12,7 @@ model_attributes = {
     "status": TransformRequest.status
 }
 parser = reqparse.RequestParser()
+parser.add_argument("page", default=1, type=int)
 sort_choices = tuple(model_attributes.keys())
 parser.add_argument(
     "sort",
@@ -29,7 +30,6 @@ parser.add_argument(
 
 
 def dashboard(template_name: str, user_specific=False):
-    page = request.args.get('page', default=1, type=int)
     args = parser.parse_args()
     sort, order = args["sort"], args["order"]
     query = TransformRequest.query
@@ -37,7 +37,7 @@ def dashboard(template_name: str, user_specific=False):
         query = query.filter_by(submitted_by=session["user_id"])
     pagination: Pagination = query \
         .order_by(getattr(model_attributes[sort], order)()) \
-        .paginate(page=page, per_page=15, error_out=False)
+        .paginate(page=args["page"], per_page=15, error_out=False)
     return render_template(
         template_name,
         pagination=pagination,

--- a/servicex/web/global_dashboard.py
+++ b/servicex/web/global_dashboard.py
@@ -1,14 +1,49 @@
+import itertools
+
 from flask import render_template, request
+from flask_restful import reqparse
 from flask_sqlalchemy import Pagination
 
 from servicex.decorators import admin_required
 from servicex.models import TransformRequest
 
 
+parser = reqparse.RequestParser()
+sort_choices = ("start", "finish", "status")
+parser.add_argument(
+    "sort",
+    choices=sort_choices,
+    default="finish",
+    help=f"Sort must be one of: {', '.join(map(repr, sort_choices))}."
+)
+order_choices = ("asc", "desc")
+parser.add_argument(
+    "order",
+    choices=order_choices,
+    default="desc",
+    help="Order must be 'asc' or 'desc'."
+)
+dropdown_options = list(itertools.product(sort_choices, order_choices))
+
+
 @admin_required
 def global_dashboard():
-    page = request.args.get('page', 1, type=int)
-    pagination: Pagination = TransformRequest.query\
-        .order_by(TransformRequest.finish_time.desc(), TransformRequest.submit_time.desc())\
+    page = request.args.get('page', default=1, type=int)
+    args = parser.parse_args()
+    sort, order = args["sort"], args["order"]
+    model_attributes = {
+        "finish": TransformRequest.finish_time,
+        "start": TransformRequest.submit_time,
+        "status": TransformRequest.status
+    }
+    sort_attr = model_attributes[sort]
+    pagination: Pagination = TransformRequest.query \
+        .order_by(getattr(sort_attr, order)()) \
         .paginate(page=page, per_page=25, error_out=False)
-    return render_template("global_dashboard.html", pagination=pagination)
+    return render_template(
+        "global_dashboard.html",
+        pagination=pagination,
+        dropdown_options=dropdown_options,
+        active_sort=sort,
+        active_order=order
+    )

--- a/servicex/web/global_dashboard.py
+++ b/servicex/web/global_dashboard.py
@@ -1,49 +1,7 @@
-import itertools
-
-from flask import render_template, request
-from flask_restful import reqparse
-from flask_sqlalchemy import Pagination
-
 from servicex.decorators import admin_required
-from servicex.models import TransformRequest
-
-
-parser = reqparse.RequestParser()
-sort_choices = ("start", "finish", "status")
-parser.add_argument(
-    "sort",
-    choices=sort_choices,
-    default="finish",
-    help=f"Sort must be one of: {', '.join(map(repr, sort_choices))}."
-)
-order_choices = ("asc", "desc")
-parser.add_argument(
-    "order",
-    choices=order_choices,
-    default="desc",
-    help="Order must be 'asc' or 'desc'."
-)
-dropdown_options = list(itertools.product(sort_choices, order_choices))
+from servicex.web.dashboard import dashboard
 
 
 @admin_required
 def global_dashboard():
-    page = request.args.get('page', default=1, type=int)
-    args = parser.parse_args()
-    sort, order = args["sort"], args["order"]
-    model_attributes = {
-        "finish": TransformRequest.finish_time,
-        "start": TransformRequest.submit_time,
-        "status": TransformRequest.status
-    }
-    sort_attr = model_attributes[sort]
-    pagination: Pagination = TransformRequest.query \
-        .order_by(getattr(sort_attr, order)()) \
-        .paginate(page=page, per_page=25, error_out=False)
-    return render_template(
-        "global_dashboard.html",
-        pagination=pagination,
-        dropdown_options=dropdown_options,
-        active_sort=sort,
-        active_order=order
-    )
+    return dashboard("global_dashboard.html", user_specific=False)

--- a/servicex/web/user_dashboard.py
+++ b/servicex/web/user_dashboard.py
@@ -1,15 +1,7 @@
-from flask import render_template, request, session
-from flask_sqlalchemy import Pagination
-
 from servicex.decorators import oauth_required
-from servicex.models import TransformRequest
+from servicex.web.dashboard import dashboard
 
 
 @oauth_required
 def user_dashboard():
-    page = request.args.get('page', 1, type=int)
-    pagination: Pagination = TransformRequest.query\
-        .filter_by(submitted_by=session["user_id"])\
-        .order_by(TransformRequest.finish_time.desc(), TransformRequest.submit_time.desc())\
-        .paginate(page=page, per_page=15, error_out=False)
-    return render_template("user_dashboard.html", pagination=pagination)
+    return dashboard("user_dashboard.html", user_specific=True)

--- a/tests/web/test_global_dashboard.py
+++ b/tests/web/test_global_dashboard.py
@@ -10,7 +10,7 @@ class TestGlobalDashboard(WebTestBase):
 
     @fixture
     def mock_query(self, mocker):
-        mock_tr = mocker.patch("servicex.web.global_dashboard.TransformRequest")
+        mock_tr = mocker.patch("servicex.web.dashboard.TransformRequest")
         return mock_tr.query.order_by.return_value
 
     def test_get_empty_state(self, client, user, mock_query, captured_templates):

--- a/tests/web/test_user_dashboard.py
+++ b/tests/web/test_user_dashboard.py
@@ -10,7 +10,7 @@ class TestUserDashboard(WebTestBase):
 
     @fixture
     def mock_query(self, mocker):
-        mock_tr = mocker.patch("servicex.web.user_dashboard.TransformRequest")
+        mock_tr = mocker.patch("servicex.web.dashboard.TransformRequest")
         return mock_tr.query.filter_by.return_value.order_by.return_value
 
     def test_get_empty_state(self, client, user, mock_query, captured_templates):


### PR DESCRIPTION
This PR adds a "sort" dropdown to the dashboard. The UI is inspired by sort dropdown in GitHub search.

![image](https://user-images.githubusercontent.com/5485577/137520665-7c4b81eb-15b2-4c45-9637-4179b083efd0.png)

It also contains some refactoring to reduce code duplication and share code between the global/user dashboards.

Partial fix for ssl-hep/ServiceX#352. The ability to change the page size is out of scope, and will be completed in a later PR.