### PR TITLE
Pin MarkupSafe to avoid import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ globus_sdk
 cryptography
 bootstrap-flask
 humanize
+MarkupSafe == 2.0.1

--- a/servicex/rabbit_adaptor.py
+++ b/servicex/rabbit_adaptor.py
@@ -31,7 +31,6 @@ import random
 import logging
 
 import pika
-from flask import current_app
 
 
 class RabbitAdaptor(object):
@@ -50,7 +49,6 @@ class RabbitAdaptor(object):
         logger = logging.getLogger(__name__)
         logger.addHandler(logging.NullHandler())
         self.logger = logger
-
 
     def connect(self):
         """This method connects to RabbitMQ, returning the connection handle.


### PR DESCRIPTION
soft_unicode was removed from MarkupSafe in 2.1.0.  Pin to a working version.  See https://github.com/ssl-hep/ServiceX_App/runs/5326186779?check_suite_focus=true for a test run where this caused a failure

Signed-off-by: Suchandra Thapa <suchandra@gmail.com>