### PR TITLE
pin MarkupSafe to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ globus_sdk
 cryptography
 bootstrap-flask
 humanize
+MarkupSafe == 2.0.1


### PR DESCRIPTION
MarkupSafe 2.1.0 breaks the build due to deprecated function removal