### PR TITLE
Add Chunk Size to Request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 .pytest_cache/
 .vscode/settings.json
 venv/
+.venv/

--- a/servicex/lookup_result_processor.py
+++ b/servicex/lookup_result_processor.py
@@ -45,6 +45,7 @@ class LookupResultProcessor:
             'tree-name': submitted_request.tree_name,
             "service-endpoint": self.advertised_endpoint +
             "servicex/internal/transformation/" + request_id,
+            "chunk-size": "1000",
             "result-destination": submitted_request.result_destination
         }
 

--- a/tests/test_lookup_result_processor.py
+++ b/tests/test_lookup_result_processor.py
@@ -59,9 +59,9 @@ class TestLookupResultProcessor(ResourceTestBase):
                  "columns": 'electron.eta(), muon.pt()',
                  "file-path": "/foo/bar.root",
                  "tree-name": "Events",
-                 "chunk-size": "1000",
                  "service-endpoint":
                      "http://cern.analysis.ch:5000/servicex/internal/transformation/BR549",
+                 "chunk-size": "1000",
                  'result-destination': 'object-store'
                  }))
 

--- a/tests/test_lookup_result_processor.py
+++ b/tests/test_lookup_result_processor.py
@@ -59,6 +59,7 @@ class TestLookupResultProcessor(ResourceTestBase):
                  "columns": 'electron.eta(), muon.pt()',
                  "file-path": "/foo/bar.root",
                  "tree-name": "Events",
+                 "chunk-size": "1000",
                  "service-endpoint":
                      "http://cern.analysis.ch:5000/servicex/internal/transformation/BR549",
                  'result-destination': 'object-store'


### PR DESCRIPTION
* The older versions of the transformers look for `chunk-size` as part of the transform request
* They don't actually do anything with them
* The current version of the `ServiceX_App` does not add `chunk-size` into the query
* We are not able to update the CMS transformer image right now

By putting a dummy `chunk-size` in we allow the old version of the CMS image to work until the new side-car feature is ready.