### PR TITLE
Shut Down Transform if Dataset is Empty

### DIFF
--- a/servicex/resources/internal/fileset_complete.py
+++ b/servicex/resources/internal/fileset_complete.py
@@ -55,4 +55,6 @@ class FilesetComplete(ServiceXResource):
         db.session.commit()
 
         if summary['files'] == 0:
-            TransformerFileComplete.transform_complete(self.logger, rec, self.transformer_manager)
+            TransformerFileComplete.transform_complete(current_app.logger,
+                                                       rec,
+                                                       self.transformer_manager)

--- a/servicex/resources/internal/fileset_complete.py
+++ b/servicex/resources/internal/fileset_complete.py
@@ -29,12 +29,14 @@ from flask import request, current_app
 
 from servicex.models import TransformRequest, db
 from servicex.resources.servicex_resource import ServiceXResource
+from servicex.resources.internal.transformer_file_complete import TransformerFileComplete
 
 
 class FilesetComplete(ServiceXResource):
     @classmethod
-    def make_api(cls, lookup_result_processor):
+    def make_api(cls, lookup_result_processor, transformer_manager):
         cls.lookup_result_processor = lookup_result_processor
+        cls.transformer_manager = transformer_manager
         return cls
 
     def put(self, request_id):
@@ -51,3 +53,6 @@ class FilesetComplete(ServiceXResource):
             did_lookup_time=summary['elapsed-time']
         )
         db.session.commit()
+
+        if summary['files'] == 0:
+            TransformerFileComplete.transform_complete(self.logger, rec, self.transformer_manager)

--- a/servicex/resources/internal/transformer_file_complete.py
+++ b/servicex/resources/internal/transformer_file_complete.py
@@ -26,9 +26,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from datetime import datetime, timezone
+from logging import Logger
 
 from flask import request, current_app
 
+from servicex import TransformerManager
 from servicex.models import TransformRequest, TransformationResult, DatasetFile, db
 from servicex.resources.servicex_resource import ServiceXResource
 
@@ -70,14 +72,17 @@ class TransformerFileComplete(ServiceXResource):
 
         files_remaining = transform_req.files_remaining
         if files_remaining is not None and files_remaining == 0:
-            namespace = current_app.config['TRANSFORMER_NAMESPACE']
-            current_app.logger.info("Job is all done... shutting down transformers",
-                                    extra={'requestId': request_id})
-            self.transformer_manager.shutdown_transformer_job(request_id, namespace)
-            transform_req.status = "Complete"
-            transform_req.finish_time = datetime.now(tz=timezone.utc)
-            transform_req.save_to_db()
-
+            self.transform_complete(self.logger, transform_req, self.transformer_manager)
         db.session.commit()
 
         return "Ok"
+
+    @staticmethod
+    def transform_complete(logger: Logger, transform_req: TransformRequest,
+                           transformer_manager: TransformerManager):
+        namespace = current_app.config['TRANSFORMER_NAMESPACE']
+        logger.info(f"Job {transform_req.request_id} is all done... shutting down transformers")
+        transformer_manager.shutdown_transformer_job(transform_req.request_id, namespace)
+        transform_req.status = "Complete"
+        transform_req.finish_time = datetime.now(tz=timezone.utc)
+        transform_req.save_to_db()

--- a/servicex/resources/internal/transformer_file_complete.py
+++ b/servicex/resources/internal/transformer_file_complete.py
@@ -72,7 +72,7 @@ class TransformerFileComplete(ServiceXResource):
 
         files_remaining = transform_req.files_remaining
         if files_remaining is not None and files_remaining == 0:
-            self.transform_complete(self.logger, transform_req, self.transformer_manager)
+            self.transform_complete(current_app.logger, transform_req, self.transformer_manager)
         db.session.commit()
 
         return "Ok"

--- a/servicex/routes.py
+++ b/servicex/routes.py
@@ -134,7 +134,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     api.add_resource(AddFileToDataset,
                      '/servicex/internal/transformation/<string:request_id>/files')
 
-    FilesetComplete.make_api(lookup_result_processor)
+    FilesetComplete.make_api(lookup_result_processor, transformer_manager)
     api.add_resource(FilesetComplete,
                      '/servicex/internal/transformation/<string:request_id>/complete')
 

--- a/tests/resources/internal/test_fileset_complete.py
+++ b/tests/resources/internal/test_fileset_complete.py
@@ -25,13 +25,17 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from servicex import LookupResultProcessor
+from servicex.models import TransformRequest
+from servicex import LookupResultProcessor, TransformerManager
 from tests.resource_test_base import ResourceTestBase
 
 
 class TestFilesetComplete(ResourceTestBase):
     def test_put_fileset_complete(self, mocker):
         import servicex
+        mock_transformer_manager = mocker.MagicMock(TransformerManager)
+        mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
+
         submitted_request = self._generate_transform_request()
         mock_transform_request_read = mocker.patch.object(
             servicex.models.TransformRequest,
@@ -39,8 +43,10 @@ class TestFilesetComplete(ResourceTestBase):
             return_value=submitted_request)
 
         mock_processor = mocker.MagicMock(LookupResultProcessor)
+        mocker.patch.object(TransformRequest, "save_to_db")
 
-        client = self._test_client(lookup_result_processor=mock_processor)
+        client = self._test_client(lookup_result_processor=mock_processor,
+                                   transformation_manager=mock_transformer_manager)
 
         response = client.put('/servicex/internal/transformation/1234/complete',
                               json={
@@ -60,3 +66,44 @@ class TestFilesetComplete(ResourceTestBase):
             total_bytes=2046,
             did_lookup_time=42
         )
+        mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+
+    def test_put_fileset_complete_empty_dataset(self, mocker):
+        import servicex
+        mock_transformer_manager = mocker.MagicMock(TransformerManager)
+        mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
+
+        submitted_request = self._generate_transform_request()
+        mock_transform_request_read = mocker.patch.object(
+            servicex.models.TransformRequest,
+            'lookup',
+            return_value=submitted_request)
+
+        mock_processor = mocker.MagicMock(LookupResultProcessor)
+        mocker.patch.object(TransformRequest, "save_to_db")
+        submitted_request.save_to_db = mocker.Mock()
+
+        client = self._test_client(lookup_result_processor=mock_processor,
+                                   transformation_manager=mock_transformer_manager)
+
+        response = client.put('/servicex/internal/transformation/BR549/complete',
+                              json={
+                                  'files': 0,
+                                  'files-skipped': 0,
+                                  'total-events': 0,
+                                  'total-bytes': 0,
+                                  'elapsed-time': 0
+                              })
+        assert response.status_code == 200
+        mock_transform_request_read.assert_called_with('BR549')
+        mock_processor.report_fileset_complete.assert_called_with(
+            submitted_request,
+            num_files=0,
+            num_skipped=0,
+            total_events=0,
+            total_bytes=0,
+            did_lookup_time=0
+        )
+
+        assert submitted_request.status == 'Complete'
+        mock_transformer_manager.shutdown_transformer_job.assert_called_with("BR549", "my-ws")

--- a/tests/resources/internal/test_transform_file_complete.py
+++ b/tests/resources/internal/test_transform_file_complete.py
@@ -108,13 +108,13 @@ class TestTransformFileComplete(ResourceTestBase):
         mocker.patch.object(TransformRequest, "save_to_db")
 
         client = self._test_client(transformation_manager=mock_transformer_manager)
-        response = client.put('/servicex/internal/transformation/1234/file-complete',
+        response = client.put('/servicex/internal/transformation/BR549/file-complete',
                               json=self._generate_file_complete_request())
 
         assert response.status_code == 200
         assert fake_req.finish_time is not None
-        mock_transform_request_read.assert_called_with('1234')
-        mock_transformer_manager.shutdown_transformer_job.assert_called_with('1234',
+        mock_transform_request_read.assert_called_with('BR549')
+        mock_transformer_manager.shutdown_transformer_job.assert_called_with('BR549',
                                                                              'my-ws')
 
     def test_put_transform_file_complete_unknown_request_id(self, mocker):


### PR DESCRIPTION
# Problem
If the DID finder reports an empty dataset the transformer remains stuck in a "running" state

Partial solution to [DID_Finder_lib issue 18](https://github.com/ssl-hep/ServiceX_DID_Finder_lib/issues/18)

# Approach
Factored out the code for shutting down a transform at the end from the `TransformerFileComplete` class. This is called from `FilesetComplete` if the dataset size is zero