### PR TITLE
Add access-control-allow-origin * to responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask>=1.1.2,<2.0
 Flask-WTF
+Flask-Cors
 wtforms
 email-validator==1.1.2
 pika
@@ -10,7 +11,7 @@ flask-sqlalchemy
 Flask-Migrate
 kubernetes
 minio
-psycopg2
+psycopg2-binary
 globus_sdk
 cryptography
 bootstrap-flask

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -33,6 +33,7 @@ import os
 
 from flask import Flask
 from flask_bootstrap import Bootstrap5
+from flask_cors import CORS
 from flask_jwt_extended import (JWTManager)
 from flask_restful import Api
 
@@ -92,6 +93,7 @@ def create_app(test_config=None,
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
     Bootstrap5(app)
+    CORS(app)
 
     JWTManager(app)
 


### PR DESCRIPTION
# Problem
ServiceX Dashboard JupyterLab plugin is failing due to a missing Cross Origin Access header.
Solution to [Lab Extension Issue 2](https://github.com/ssl-hep/servicex-labextension/issues/2)

# Approach
Added a dependency to the [Flask CORS library](https://flask-cors.readthedocs.io/en/latest/#) and initialized the app.

# How to test
Run the app and fire a request at the service. Look at the headers in the response and observe the following among them:
```
Access-Control-Allow-Origin: *
```