### PR TITLE
Added parameters to top level json result

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask>=1.1.2,<2.0
 Flask-WTF
+Flask-Cors
 wtforms
 email-validator==1.1.2
 pika
@@ -10,7 +11,7 @@ flask-sqlalchemy
 Flask-Migrate
 kubernetes
 minio
-psycopg2
+psycopg2-binary
 globus_sdk
 cryptography
 bootstrap-flask

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -33,6 +33,7 @@ import os
 
 from flask import Flask
 from flask_bootstrap import Bootstrap5
+from flask_cors import CORS
 from flask_jwt_extended import (JWTManager)
 from flask_restful import Api
 
@@ -92,6 +93,7 @@ def create_app(test_config=None,
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
     Bootstrap5(app)
+    CORS(app)
 
     JWTManager(app)
 

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -180,6 +180,11 @@ class TransformRequest(db.Model):
             'workflow-name': self.workflow_name,
             'generated-code-cm': self.generated_code_cm,
             'status': self.status,
+            'submit-time': self.submit_time,
+            'finish-time' : self.finish_time,
+            'files-processed': self.files_processed,
+            'files-skipped': self.files_skipped,
+            'files-remaining': self.files_remaining,
             'failure-info': self.failure_description,
             'app-version': self.app_version,
             'code-gen-image': self.code_gen_image

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -167,7 +167,8 @@ class TransformRequest(db.Model):
         db.session.flush()
 
     def to_json(self):
-        return {
+        iso_fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
+        result_obj =  {
             'request_id': self.request_id,
             'did': self.did,
             'columns': self.columns,
@@ -180,15 +181,18 @@ class TransformRequest(db.Model):
             'workflow-name': self.workflow_name,
             'generated-code-cm': self.generated_code_cm,
             'status': self.status,
-            'submit-time': self.submit_time,
-            'finish-time' : self.finish_time,
-            'files-processed': self.files_processed,
-            'files-skipped': self.files_skipped,
-            'files-remaining': self.files_remaining,
             'failure-info': self.failure_description,
             'app-version': self.app_version,
-            'code-gen-image': self.code_gen_image
+            'code-gen-image': self.code_gen_image,
+            'files-processed': self.files_processed,
+            'files-skipped': self.files_failed,
+            'files-remaining': self.files_remaining,
+            'submit-time': str(self.submit_time.strftime(iso_fmt)),
+            'finish-time' : str(self.finish_time)
         }
+        if self.finish_time is not None:
+            result_obj['finish-time'] = str(self.finish_time.strftime(iso_fmt))
+        return result_obj
 
     @classmethod
     def return_json(cls, requests: Iterable['TransformRequest']):


### PR DESCRIPTION

### Problem

Performance of ServiceX Jupyterlab plugin is limited due to the absence of certain parameters in the top level json result.
Potential solution to [Lab Extension Issue 3](https://github.com/ssl-hep/servicex-labextension/issues/3)

### Approach

Added parameters to object that is returned in function to_json in servicex/models.py, which ends up being used to create the top level json result.

### Testing

The top level json result should now contain 5 additional parameters (submit-time, finish-time, files-processed, files-remaining, files-skipped)

