### PR TITLE
Don't return just the first letter of the file with error

### DIFF
--- a/servicex/resources/transformation/errors.py
+++ b/servicex/resources/transformation/errors.py
@@ -47,7 +47,9 @@ class TransformErrors(ServiceXResource):
             return {'message': msg}, 404
         results = [{
             "pod-name": result[1].pod_name,
-            "file": result[0].paths[0],
+            "file": result[0].paths
+            if isinstance(result[0].paths, str)
+            else result[0].paths[0],
             "events": result[0].file_events,
             "info": result[1].info
         } for result in FileStatus.failures_for_request(request_id)]


### PR DESCRIPTION
# Problem
Error reports are showing just the first letter of the file that generated the error

Solution to [ServiceX Issue 408](https://github.com/ssl-hep/ServiceX/issues/408)

# Approach
There is inconsistency between the transformers over what is returned in the `paths` property. Some return a single string instead of a list. In the case of a list it returns the first filename for simplicity. If the `paths` property is a string this will just do a substring operation and return the first character.

Add a check on the type of the `paths` property and either return the string or the first element of the list