### PR TITLE
Added parameters to top level json result 

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -180,6 +180,11 @@ class TransformRequest(db.Model):
             'workflow-name': self.workflow_name,
             'generated-code-cm': self.generated_code_cm,
             'status': self.status,
+            'submit-time': self.submit_time,
+            'finish-time' : self.finish_time,
+            'files-processed': self.files_processed,
+            'files-skipped': self.files_skipped,
+            'files-remaining': self.files_remaining,
             'failure-info': self.failure_description,
             'app-version': self.app_version,
             'code-gen-image': self.code_gen_image

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -167,7 +167,8 @@ class TransformRequest(db.Model):
         db.session.flush()
 
     def to_json(self):
-        return {
+        iso_fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
+        result_obj =  {
             'request_id': self.request_id,
             'did': self.did,
             'columns': self.columns,
@@ -180,15 +181,18 @@ class TransformRequest(db.Model):
             'workflow-name': self.workflow_name,
             'generated-code-cm': self.generated_code_cm,
             'status': self.status,
-            'submit-time': self.submit_time,
-            'finish-time' : self.finish_time,
-            'files-processed': self.files_processed,
-            'files-skipped': self.files_skipped,
-            'files-remaining': self.files_remaining,
             'failure-info': self.failure_description,
             'app-version': self.app_version,
-            'code-gen-image': self.code_gen_image
+            'code-gen-image': self.code_gen_image,
+            'files-processed': self.files_processed,
+            'files-skipped': self.files_failed,
+            'files-remaining': self.files_remaining,
+            'submit-time': str(self.submit_time.strftime(iso_fmt)),
+            'finish-time' : str(self.finish_time)
         }
+        if self.finish_time is not None:
+            result_obj['finish-time'] = str(self.finish_time.strftime(iso_fmt))
+        return result_obj
 
     @classmethod
     def return_json(cls, requests: Iterable['TransformRequest']):

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -168,7 +168,7 @@ class TransformRequest(db.Model):
 
     def to_json(self):
         iso_fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
-        result_obj =  {
+        result_obj = {
             'request_id': self.request_id,
             'did': self.did,
             'columns': self.columns,
@@ -188,7 +188,7 @@ class TransformRequest(db.Model):
             'files-skipped': self.files_failed,
             'files-remaining': self.files_remaining,
             'submit-time': str(self.submit_time.strftime(iso_fmt)),
-            'finish-time' : str(self.finish_time)
+            'finish-time': str(self.finish_time)
         }
         if self.finish_time is not None:
             result_obj['finish-time'] = str(self.finish_time.strftime(iso_fmt))

--- a/tests/resources/transformation/test_get_one.py
+++ b/tests/resources/transformation/test_get_one.py
@@ -12,26 +12,9 @@ class TestTransformationRequest(ResourceTestBase):
         client = self._test_client(extra_config={'OBJECT_STORE_ENABLED': False})
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
-        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
-                                 'columns': 'electron.eta(), muon.pt()',
-                                 'selection': None,
-                                 'tree-name': "Events",
-                                 'image': 'ssl-hep/foo:latest',
-                                 'workers': 42,
-                                 'result-destination': None,
-                                 'result-format': 'arrow',
-                                 'workflow-name': None,
-                                 'generated-code-cm': None,
-                                 'status': "Submitted",
-                                 'submit-time': '0001-01-01T00:00:00.000000Z',
-                                 'failure-info': None,
-                                 'files-processed': 0,
-                                 'files-remaining': None,
-                                 'files-skipped': 0,
-                                 'finish-time': 'None',
-                                 'app-version': "1.0.1",
-                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
-                                 }
+        transform = response.json
+
+        assert transform['request_id'] == 'BR549'
         mock_transform_request_read.assert_called_with('1234')
 
     def test_get_single_request_with_object_store(self, mocker):
@@ -54,32 +37,8 @@ class TestTransformationRequest(ResourceTestBase):
         client = self._test_client(extra_config=local_config)
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
-        print(response.json)
-        assert response.json == {'request_id': 'BR549', 'did': '123-456-789',
-                                 'columns': 'electron.eta(), muon.pt()',
-                                 'selection': None,
-                                 'tree-name': "Events",
-                                 'image': 'ssl-hep/foo:latest',
-                                 'workers': 42,
-                                 'result-destination': 'object-store',
-                                 'result-format': 'arrow',
-                                 'minio-endpoint': 'minio.servicex.com:9000',
-                                 'minio-secured': True,
-                                 'minio-access-key': 'miniouser',
-                                 'minio-secret-key': 'leftfoot1',
-                                 'workflow-name': None,
-                                 'generated-code-cm': None,
-                                 'status': "Submitted",
-                                 'submit-time': '0001-01-01T00:00:00.000000Z',
-                                 'failure-info': None,
-                                 'files-processed': 0,
-                                 'files-remaining': None,
-                                 'files-skipped': 0,
-                                 'finish-time': 'None',
-                                 'app-version': "1.0.1",
-                                 'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
-                                 }
-
+        transform = response.json
+        assert transform['request_id'] == 'BR549'
         mock_transform_request_read.assert_called_with('1234')
 
     def test_get_single_request_404(self, mocker, client):

--- a/tests/resources/transformation/test_get_one.py
+++ b/tests/resources/transformation/test_get_one.py
@@ -23,7 +23,12 @@ class TestTransformationRequest(ResourceTestBase):
                                  'workflow-name': None,
                                  'generated-code-cm': None,
                                  'status': "Submitted",
+                                 'submit-time': '0001-01-01T00:00:00.000000Z',
                                  'failure-info': None,
+                                 'files-processed': 0,
+                                 'files-remaining': None,
+                                 'files-skipped': 0,
+                                 'finish-time': 'None',
                                  'app-version': "1.0.1",
                                  'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
                                  }
@@ -65,7 +70,12 @@ class TestTransformationRequest(ResourceTestBase):
                                  'workflow-name': None,
                                  'generated-code-cm': None,
                                  'status': "Submitted",
+                                 'submit-time': '0001-01-01T00:00:00.000000Z',
                                  'failure-info': None,
+                                 'files-processed': 0,
+                                 'files-remaining': None,
+                                 'files-skipped': 0,
+                                 'finish-time': 'None',
                                  'app-version': "1.0.1",
                                  'code-gen-image': 'sslhep/servicex_code_gen_func_adl_xaod:develop'
                                  }


### PR DESCRIPTION
(Moved from Jake's PR #181 )
### Problem

Performance of ServiceX Jupyterlab plugin is limited due to the absence of certain parameters in the top level json result.
Potential solution to [Lab Extension Issue 3](https://github.com/ssl-hep/servicex-labextension/issues/3)

### Approach

Added parameters to object that is returned in function to_json in servicex/models.py, which ends up being used to create the top level json result.

### Testing

The top level json result should now contain 5 additional parameters (submit-time, finish-time, files-processed, files-remaining, files-skipped)
